### PR TITLE
chore: bump python-dotenv to 1.2.2

### DIFF
--- a/services/api_fastapi/pyproject.toml
+++ b/services/api_fastapi/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "uvicorn[standard]>=0.30,<1.0",
     "google-cloud-firestore>=2.14,<3.0",
     "firebase-admin>=6.5,<8.0",
-    "python-dotenv>=1.0,<2.0",
+    "python-dotenv>=1.2.2,<2.0",
     "structlog>=24.1,<26.0",
     "scoring-engine",
 ]

--- a/services/api_fastapi/uv.lock
+++ b/services/api_fastapi/uv.lock
@@ -70,7 +70,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.111,<1.0" },
     { name = "firebase-admin", specifier = ">=6.5,<8.0" },
     { name = "google-cloud-firestore", specifier = ">=2.14,<3.0" },
-    { name = "python-dotenv", specifier = ">=1.0,<2.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2,<2.0" },
     { name = "scoring-engine", directory = "../scoring_engine" },
     { name = "structlog", specifier = ">=24.1,<26.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1.0" },
@@ -1216,11 +1216,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/services/ingest_worker/pyproject.toml
+++ b/services/ingest_worker/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "google-cloud-bigquery>=3.17,<4.0",
     "google-cloud-firestore>=2.26.0,<3.0",
     "structlog>=24.1,<26.0",
-    "python-dotenv>=1.0,<2.0",
+    "python-dotenv>=1.2.2,<2.0",
 ]
 
 [dependency-groups]

--- a/services/ingest_worker/uv.lock
+++ b/services/ingest_worker/uv.lock
@@ -587,7 +587,7 @@ requires-dist = [
     { name = "google-cloud-firestore", specifier = ">=2.26.0,<3.0" },
     { name = "google-cloud-storage", specifier = ">=3.10.1,<4.0" },
     { name = "httpx", specifier = ">=0.28.1,<1.0" },
-    { name = "python-dotenv", specifier = ">=1.0,<2.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2,<2.0" },
     { name = "structlog", specifier = ">=24.1,<26.0" },
 ]
 
@@ -879,11 +879,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Bump the direct python-dotenv dependency floor to the patched 1.2.2 release in the API and ingest worker services, and refresh the matching uv lockfiles.

## What this fixes
- closes the remaining python-dotenv alerts in services/api_fastapi/uv.lock and services/ingest_worker/uv.lock

## Validation
- uv run --cache-dir /tmp/uv-cache pytest tests (services/api_fastapi)
- uv run --cache-dir /tmp/uv-cache pytest tests (services/ingest_worker)
