### PR TITLE
chore(deps): bump react from 19.2.4 to 19.2.5

### DIFF
--- a/apps/dashboard_nextjs/package-lock.json
+++ b/apps/dashboard_nextjs/package-lock.json
@@ -12,7 +12,7 @@
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.564.0",
         "next": "16.2.9",
-        "react": "19.2.4",
+        "react": "19.2.5",
         "react-dom": "19.2.3",
         "suncalc": "^1.9.0"
       },
@@ -5547,9 +5547,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/apps/dashboard_nextjs/package.json
+++ b/apps/dashboard_nextjs/package.json
@@ -13,7 +13,7 @@
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.564.0",
     "next": "16.2.9",
-    "react": "19.2.4",
+    "react": "19.2.5",
     "react-dom": "19.2.3",
     "suncalc": "^1.9.0"
   },


### PR DESCRIPTION
Manual resolution of #68 (Dependabot could not auto-rebase its lockfile after the security PR #76 rewrote `package-lock.json`).

Bumps react 19.2.4 → 19.2.5. `npm run build` passes locally.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)