### PR TITLE
chore(deps): bump lucide-react to v1 + inline GitHub icon

### DIFF
--- a/apps/dashboard_nextjs/package-lock.json
+++ b/apps/dashboard_nextjs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "framer-motion": "^12.38.0",
         "lottie-react": "^2.4.1",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^1.21.0",
         "next": "16.2.9",
         "react": "19.2.7",
         "react-dom": "19.2.3",
@@ -5014,9 +5014,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.564.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.564.0.tgz",
-      "integrity": "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/apps/dashboard_nextjs/package.json
+++ b/apps/dashboard_nextjs/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "framer-motion": "^12.38.0",
     "lottie-react": "^2.4.1",
-    "lucide-react": "^0.564.0",
+    "lucide-react": "^1.21.0",
     "next": "16.2.9",
     "react": "19.2.7",
     "react-dom": "19.2.3",

--- a/apps/dashboard_nextjs/src/components/AboutView.tsx
+++ b/apps/dashboard_nextjs/src/components/AboutView.tsx
@@ -5,7 +5,6 @@ import { motion, useInView, type Variants } from "framer-motion";
 import {
   Layers,
   Zap,
-  Github,
   ChevronRight,
   PawPrint,
   Waves,
@@ -17,6 +16,7 @@ import {
   Thermometer,
 } from "lucide-react";
 import Link from "next/link";
+import GithubIcon from "./GithubIcon";
 
 /* ── Counter hook ────────────────────────────────────────────────── */
 
@@ -544,7 +544,7 @@ export default function AboutView() {
         custom={4}
       >
         <div className="flex items-center gap-1.5 mb-3">
-          <Github size={14} className="text-slate-400" />
+          <GithubIcon size={14} className="text-slate-400" />
           <span className="text-[11px] font-medium text-slate-400 uppercase tracking-widest">
             Open Source
           </span>
@@ -570,7 +570,7 @@ export default function AboutView() {
           whileTap={{ scale: 0.96 }}
           transition={{ duration: 0.15 }}
         >
-          <Github size={13} />
+          <GithubIcon size={13} />
           View on GitHub
         </motion.a>
       </ScrollReveal>

--- a/apps/dashboard_nextjs/src/components/Footer.tsx
+++ b/apps/dashboard_nextjs/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Github } from "lucide-react";
+import GithubIcon from "./GithubIcon";
 
 export default function Footer() {
   return (
@@ -9,7 +9,7 @@ export default function Footer() {
         rel="noopener noreferrer"
         className="flex items-center justify-center gap-2 text-slate-500 hover:text-slate-700 dark:text-slate-600 dark:hover:text-slate-400 transition-colors cursor-pointer"
       >
-        <Github size={14} />
+        <GithubIcon size={14} />
         <span className="text-[11px] font-medium">Built by NitBuk</span>
       </a>
     </footer>

--- a/apps/dashboard_nextjs/src/components/GithubIcon.tsx
+++ b/apps/dashboard_nextjs/src/components/GithubIcon.tsx
@@ -1,0 +1,24 @@
+import type { SVGProps } from "react";
+
+/**
+ * GitHub mark as an inline SVG. lucide-react v1 removed brand/logo icons,
+ * so we render the canonical mark locally. Mirrors the lucide icon API
+ * (numeric `size`, `className`, plus any SVG props), using `currentColor`.
+ */
+export default function GithubIcon({
+  size = 24,
+  ...props
+}: SVGProps<SVGSVGElement> & { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Manual resolution of #66. lucide-react v1 removed brand/logo icons (incl. the `Github` mark used in `Footer.tsx` and `AboutView.tsx`), which is why #66's build panicked.

## Changes
- Bump lucide-react 0.564 → ^1.21.0
- Add `src/components/GithubIcon.tsx` — inline GitHub mark (lucide-compatible `size`/SVG props, `currentColor`)
- Swap `Github` → `GithubIcon` in `Footer.tsx` and `AboutView.tsx`

## Verification
- `npm run lint` clean, `npm run build` passes
- Verified in browser: GitHub icon renders in footer, "OPEN SOURCE" heading, and "View on GitHub" button

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)