### PR TITLE
Add native iOS web parity app

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Storage  Query (serving cache)
 
 **Key decisions:**
 - Scoring engine is a standalone Python package -- no GCP deps, tested in isolation, and designed to port to Dart for V2 on-device scoring
+- First-release native iOS uses the backend `/v1/public/scores` contract as the scoring source of truth, keeping web and iOS maintainable from one API surface
 - Three storage layers: raw archive (Cloud Storage), analytics (BigQuery), serving cache (Firestore) -- each optimized for a distinct access pattern
 - Cloud Run scale-to-zero fits the hourly pipeline cadence; the full stack runs within GCP free tier
 - `ForecastProvider` interface decouples data ingestion from scoring -- add a new weather source without touching the API or scoring logic
@@ -124,6 +125,7 @@ The `/status` page exposes pipeline health and a live architecture diagram:
 ```
 apps/
   dashboard_nextjs/        # Next.js web app (mobile-first, Tailwind, Framer Motion)
+  ios_go_now/              # Native SwiftUI iPhone app (primary V2 product surface)
   mobile_flutter/          # Flutter native app (V2, not yet started)
 
 services/
@@ -132,7 +134,7 @@ services/
   scoring_engine/          # Standalone scoring package (zero cloud deps)
   shared_contracts/        # Shared DTOs across services
 
-docs/                      # 14 specification documents
+docs/                      # Specification documents
 infra/                     # GCP bootstrap notes, schemas, IAM configs
 scripts/                   # Operational runbooks (diagnose-ingest.sh)
 ```

--- a/apps/ios_go_now/GoNow.xcodeproj/project.pbxproj
+++ b/apps/ios_go_now/GoNow.xcodeproj/project.pbxproj
@@ -1,0 +1,149 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		010000000000000000000001 /* GoNowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000001 /* GoNowApp.swift */; };
+		010000000000000000000002 /* AppRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000002 /* AppRootView.swift */; };
+		010000000000000000000003 /* AppTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000003 /* AppTab.swift */; };
+		010000000000000000000004 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000004 /* Models.swift */; };
+		010000000000000000000005 /* ForecastAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000005 /* ForecastAnalytics.swift */; };
+		010000000000000000000006 /* ForecastAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000006 /* ForecastAPIClient.swift */; };
+		010000000000000000000007 /* ForecastStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000007 /* ForecastStore.swift */; };
+		010000000000000000000008 /* ScoreStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000008 /* ScoreStyle.swift */; };
+		010000000000000000000009 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000009 /* Components.swift */; };
+		01000000000000000000000A /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02000000000000000000000A /* TodayView.swift */; };
+		01000000000000000000000B /* PlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02000000000000000000000B /* PlannerView.swift */; };
+		01000000000000000000000C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02000000000000000000000C /* ProfileView.swift */; };
+		01000000000000000000000D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 02000000000000000000000D /* Assets.xcassets */; };
+		010000000000000000000014 /* ForecastMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000014 /* ForecastMetric.swift */; };
+		010000000000000000000015 /* HealthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000015 /* HealthModels.swift */; };
+		010000000000000000000016 /* DayDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000016 /* DayDetailSheet.swift */; };
+		010000000000000000000017 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000017 /* StatusView.swift */; };
+		010000000000000000000018 /* FormulaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000018 /* FormulaView.swift */; };
+		010000000000000000000019 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000019 /* AboutView.swift */; };
+		010000000000000000000020 /* GoNowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000020 /* GoNowTests.swift */; };
+		010000000000000000000021 /* ForecastAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000021 /* ForecastAnalyticsTests.swift */; };
+		010000000000000000000022 /* ForecastAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000022 /* ForecastAPITests.swift */; };
+		010000000000000000000023 /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020000000000000000000023 /* Fixtures.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		030000000000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 040000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 050000000000000000000001;
+			remoteInfo = GoNow;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		020000000000000000000001 /* GoNowApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoNowApp.swift; sourceTree = "<group>"; };
+		020000000000000000000002 /* AppRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRootView.swift; sourceTree = "<group>"; };
+		020000000000000000000003 /* AppTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTab.swift; sourceTree = "<group>"; };
+		020000000000000000000004 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		020000000000000000000005 /* ForecastAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastAnalytics.swift; sourceTree = "<group>"; };
+		020000000000000000000006 /* ForecastAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastAPIClient.swift; sourceTree = "<group>"; };
+		020000000000000000000007 /* ForecastStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastStore.swift; sourceTree = "<group>"; };
+		020000000000000000000008 /* ScoreStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreStyle.swift; sourceTree = "<group>"; };
+		020000000000000000000009 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
+		02000000000000000000000A /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
+		02000000000000000000000B /* PlannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerView.swift; sourceTree = "<group>"; };
+		02000000000000000000000C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		02000000000000000000000D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		02000000000000000000000E /* Preview Content */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Preview Content"; sourceTree = "<group>"; };
+		020000000000000000000014 /* ForecastMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastMetric.swift; sourceTree = "<group>"; };
+		020000000000000000000015 /* HealthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthModels.swift; sourceTree = "<group>"; };
+		020000000000000000000016 /* DayDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayDetailSheet.swift; sourceTree = "<group>"; };
+		020000000000000000000017 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
+		020000000000000000000018 /* FormulaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaView.swift; sourceTree = "<group>"; };
+		020000000000000000000019 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
+		020000000000000000000010 /* GoNow.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GoNow.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		020000000000000000000020 /* GoNowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoNowTests.swift; sourceTree = "<group>"; };
+		020000000000000000000021 /* ForecastAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastAnalyticsTests.swift; sourceTree = "<group>"; };
+		020000000000000000000022 /* ForecastAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastAPITests.swift; sourceTree = "<group>"; };
+		020000000000000000000023 /* Fixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixtures.swift; sourceTree = "<group>"; };
+		020000000000000000000030 /* GoNowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoNowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		060000000000000000000001 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		060000000000000000000002 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		070000000000000000000001 = {isa = PBXGroup; children = (070000000000000000000002 /* GoNow */, 070000000000000000000020 /* GoNowTests */, 070000000000000000000030 /* Products */); sourceTree = "<group>"; };
+		070000000000000000000002 /* GoNow */ = {isa = PBXGroup; children = (020000000000000000000001 /* GoNowApp.swift */, 070000000000000000000003 /* App */, 070000000000000000000004 /* Domain */, 070000000000000000000005 /* Networking */, 070000000000000000000006 /* State */, 070000000000000000000007 /* DesignSystem */, 070000000000000000000008 /* Features */, 02000000000000000000000D /* Assets.xcassets */, 02000000000000000000000E /* Preview Content */); path = GoNow; sourceTree = "<group>"; };
+		070000000000000000000003 /* App */ = {isa = PBXGroup; children = (020000000000000000000002 /* AppRootView.swift */, 020000000000000000000003 /* AppTab.swift */); path = App; sourceTree = "<group>"; };
+		070000000000000000000004 /* Domain */ = {isa = PBXGroup; children = (020000000000000000000004 /* Models.swift */, 020000000000000000000014 /* ForecastMetric.swift */, 020000000000000000000015 /* HealthModels.swift */, 020000000000000000000005 /* ForecastAnalytics.swift */); path = Domain; sourceTree = "<group>"; };
+		070000000000000000000005 /* Networking */ = {isa = PBXGroup; children = (020000000000000000000006 /* ForecastAPIClient.swift */); path = Networking; sourceTree = "<group>"; };
+		070000000000000000000006 /* State */ = {isa = PBXGroup; children = (020000000000000000000007 /* ForecastStore.swift */); path = State; sourceTree = "<group>"; };
+		070000000000000000000007 /* DesignSystem */ = {isa = PBXGroup; children = (020000000000000000000008 /* ScoreStyle.swift */, 020000000000000000000009 /* Components.swift */); path = DesignSystem; sourceTree = "<group>"; };
+		070000000000000000000008 /* Features */ = {isa = PBXGroup; children = (070000000000000000000009 /* Today */, 07000000000000000000000A /* Planner */, 07000000000000000000000C /* ForecastDetails */, 07000000000000000000000B /* Profile */); path = Features; sourceTree = "<group>"; };
+		070000000000000000000009 /* Today */ = {isa = PBXGroup; children = (02000000000000000000000A /* TodayView.swift */); path = Today; sourceTree = "<group>"; };
+		07000000000000000000000A /* Planner */ = {isa = PBXGroup; children = (02000000000000000000000B /* PlannerView.swift */); path = Planner; sourceTree = "<group>"; };
+		07000000000000000000000B /* Profile */ = {isa = PBXGroup; children = (02000000000000000000000C /* ProfileView.swift */, 020000000000000000000017 /* StatusView.swift */, 020000000000000000000018 /* FormulaView.swift */, 020000000000000000000019 /* AboutView.swift */); path = Profile; sourceTree = "<group>"; };
+		07000000000000000000000C /* ForecastDetails */ = {isa = PBXGroup; children = (020000000000000000000016 /* DayDetailSheet.swift */); path = ForecastDetails; sourceTree = "<group>"; };
+		070000000000000000000020 /* GoNowTests */ = {isa = PBXGroup; children = (020000000000000000000020 /* GoNowTests.swift */, 020000000000000000000021 /* ForecastAnalyticsTests.swift */, 020000000000000000000022 /* ForecastAPITests.swift */, 020000000000000000000023 /* Fixtures.swift */); path = GoNowTests; sourceTree = "<group>"; };
+		070000000000000000000030 /* Products */ = {isa = PBXGroup; children = (020000000000000000000010 /* GoNow.app */, 020000000000000000000030 /* GoNowTests.xctest */); name = Products; sourceTree = "<group>"; };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		050000000000000000000001 /* GoNow */ = {isa = PBXNativeTarget; buildConfigurationList = 080000000000000000000010 /* Build configuration list for PBXNativeTarget "GoNow" */; buildPhases = (090000000000000000000001 /* Sources */, 060000000000000000000001 /* Frameworks */, 090000000000000000000002 /* Resources */); buildRules = (); dependencies = (); name = GoNow; productName = GoNow; productReference = 020000000000000000000010 /* GoNow.app */; productType = "com.apple.product-type.application"; };
+		050000000000000000000002 /* GoNowTests */ = {isa = PBXNativeTarget; buildConfigurationList = 080000000000000000000020 /* Build configuration list for PBXNativeTarget "GoNowTests" */; buildPhases = (090000000000000000000003 /* Sources */, 060000000000000000000002 /* Frameworks */, 090000000000000000000004 /* Resources */); buildRules = (); dependencies = (0A0000000000000000000001 /* PBXTargetDependency */); name = GoNowTests; productName = GoNowTests; productReference = 020000000000000000000030 /* GoNowTests.xctest */; productType = "com.apple.product-type.bundle.unit-test"; };
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		040000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {BuildIndependentTargetsInParallel = 1; LastSwiftUpdateCheck = 2600; LastUpgradeCheck = 2600; TargetAttributes = {050000000000000000000001 = {CreatedOnToolsVersion = 26.2; }; 050000000000000000000002 = {CreatedOnToolsVersion = 26.2; TestTargetID = 050000000000000000000001; }; }; };
+			buildConfigurationList = 080000000000000000000001 /* Build configuration list for PBXProject "GoNow" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (en, Base);
+			mainGroup = 070000000000000000000001;
+			minimizedProjectReferenceProxies = 1;
+			productRefGroup = 070000000000000000000030 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (050000000000000000000001 /* GoNow */, 050000000000000000000002 /* GoNowTests */);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		090000000000000000000002 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		090000000000000000000004 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		090000000000000000000001 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (010000000000000000000001 /* GoNowApp.swift in Sources */, 010000000000000000000002 /* AppRootView.swift in Sources */, 010000000000000000000003 /* AppTab.swift in Sources */, 010000000000000000000004 /* Models.swift in Sources */, 010000000000000000000014 /* ForecastMetric.swift in Sources */, 010000000000000000000015 /* HealthModels.swift in Sources */, 010000000000000000000005 /* ForecastAnalytics.swift in Sources */, 010000000000000000000006 /* ForecastAPIClient.swift in Sources */, 010000000000000000000007 /* ForecastStore.swift in Sources */, 010000000000000000000008 /* ScoreStyle.swift in Sources */, 010000000000000000000009 /* Components.swift in Sources */, 01000000000000000000000A /* TodayView.swift in Sources */, 01000000000000000000000B /* PlannerView.swift in Sources */, 010000000000000000000016 /* DayDetailSheet.swift in Sources */, 01000000000000000000000C /* ProfileView.swift in Sources */, 010000000000000000000017 /* StatusView.swift in Sources */, 010000000000000000000018 /* FormulaView.swift in Sources */, 010000000000000000000019 /* AboutView.swift in Sources */); runOnlyForDeploymentPostprocessing = 0; };
+		090000000000000000000003 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (010000000000000000000020 /* GoNowTests.swift in Sources */, 010000000000000000000021 /* ForecastAnalyticsTests.swift in Sources */, 010000000000000000000022 /* ForecastAPITests.swift in Sources */, 010000000000000000000023 /* Fixtures.swift in Sources */); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0A0000000000000000000001 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = 050000000000000000000001 /* GoNow */; targetProxy = 030000000000000000000001 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0B000000000000000000000001 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {ALWAYS_SEARCH_USER_PATHS = NO; ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CLANG_ANALYZER_NONNULL = YES; CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE; CLANG_CXX_LANGUAGE_STANDARD = "gnu++20"; CLANG_ENABLE_MODULES = YES; CLANG_ENABLE_OBJC_ARC = YES; CLANG_ENABLE_OBJC_WEAK = YES; CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES; CLANG_WARN_BOOL_CONVERSION = YES; CLANG_WARN_COMMA = YES; CLANG_WARN_CONSTANT_CONVERSION = YES; CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES; CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR; CLANG_WARN_DOCUMENTATION_COMMENTS = YES; CLANG_WARN_EMPTY_BODY = YES; CLANG_WARN_ENUM_CONVERSION = YES; CLANG_WARN_INFINITE_RECURSION = YES; CLANG_WARN_INT_CONVERSION = YES; CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES; CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES; CLANG_WARN_OBJC_LITERAL_CONVERSION = YES; CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR; CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES; CLANG_WARN_RANGE_LOOP_ANALYSIS = YES; CLANG_WARN_STRICT_PROTOTYPES = YES; CLANG_WARN_SUSPICIOUS_MOVE = YES; CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE; CLANG_WARN_UNREACHABLE_CODE = YES; CLANG_WARN__DUPLICATE_METHOD_MATCH = YES; COPY_PHASE_STRIP = NO; DEBUG_INFORMATION_FORMAT = dwarf; ENABLE_STRICT_OBJC_MSGSEND = YES; ENABLE_TESTABILITY = YES; ENABLE_USER_SCRIPT_SANDBOXING = YES; "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64; GCC_C_LANGUAGE_STANDARD = gnu17; GCC_DYNAMIC_NO_PIC = NO; GCC_NO_COMMON_BLOCKS = YES; GCC_OPTIMIZATION_LEVEL = 0; GCC_PREPROCESSOR_DEFINITIONS = ("DEBUG=1", "$(inherited)"); GCC_WARN_64_TO_32_BIT_CONVERSION = YES; GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR; GCC_WARN_UNDECLARED_SELECTOR = YES; GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE; GCC_WARN_UNUSED_FUNCTION = YES; GCC_WARN_UNUSED_VARIABLE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; LOCALIZATION_PREFERS_STRING_CATALOGS = YES; MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE; MTL_FAST_MATH = YES; ONLY_ACTIVE_ARCH = YES; SDKROOT = iphoneos; SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)"; SWIFT_OPTIMIZATION_LEVEL = "-Onone"; }; name = Debug; };
+		0B000000000000000000000002 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {ALWAYS_SEARCH_USER_PATHS = NO; ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CLANG_ANALYZER_NONNULL = YES; CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE; CLANG_CXX_LANGUAGE_STANDARD = "gnu++20"; CLANG_ENABLE_MODULES = YES; CLANG_ENABLE_OBJC_ARC = YES; CLANG_ENABLE_OBJC_WEAK = YES; CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES; CLANG_WARN_BOOL_CONVERSION = YES; CLANG_WARN_COMMA = YES; CLANG_WARN_CONSTANT_CONVERSION = YES; CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES; CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR; CLANG_WARN_DOCUMENTATION_COMMENTS = YES; CLANG_WARN_EMPTY_BODY = YES; CLANG_WARN_ENUM_CONVERSION = YES; CLANG_WARN_INFINITE_RECURSION = YES; CLANG_WARN_INT_CONVERSION = YES; CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES; CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES; CLANG_WARN_OBJC_LITERAL_CONVERSION = YES; CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR; CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES; CLANG_WARN_RANGE_LOOP_ANALYSIS = YES; CLANG_WARN_STRICT_PROTOTYPES = YES; CLANG_WARN_SUSPICIOUS_MOVE = YES; CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE; CLANG_WARN_UNREACHABLE_CODE = YES; CLANG_WARN__DUPLICATE_METHOD_MATCH = YES; COPY_PHASE_STRIP = NO; DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"; ENABLE_NS_ASSERTIONS = NO; ENABLE_STRICT_OBJC_MSGSEND = YES; ENABLE_USER_SCRIPT_SANDBOXING = YES; "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64; GCC_C_LANGUAGE_STANDARD = gnu17; GCC_NO_COMMON_BLOCKS = YES; GCC_WARN_64_TO_32_BIT_CONVERSION = YES; GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR; GCC_WARN_UNDECLARED_SELECTOR = YES; GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE; GCC_WARN_UNUSED_FUNCTION = YES; GCC_WARN_UNUSED_VARIABLE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; LOCALIZATION_PREFERS_STRING_CATALOGS = YES; MTL_ENABLE_DEBUG_INFO = NO; MTL_FAST_MATH = YES; SDKROOT = iphoneos; SWIFT_COMPILATION_MODE = wholemodule; VALIDATE_PRODUCT = YES; }; name = Release; };
+		0B000000000000000000000010 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_ASSET_PATHS = "\"GoNow/Preview Content\""; DEVELOPMENT_TEAM = ""; ENABLE_PREVIEWS = YES; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_KEY_CFBundleDisplayName = "Go Now"; INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.weather"; INFOPLIST_KEY_UILaunchScreen_Generation = YES; INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MARKETING_VERSION = 0.1.0; PRODUCT_BUNDLE_IDENTIFIER = com.nitbuk.gonow; PRODUCT_NAME = "$(TARGET_NAME)"; SUPPORTED_PLATFORMS = "iphoneos iphonesimulator"; SUPPORTS_MACCATALYST = NO; SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1; }; name = Debug; };
+		0B000000000000000000000011 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_ASSET_PATHS = "\"GoNow/Preview Content\""; DEVELOPMENT_TEAM = ""; ENABLE_PREVIEWS = YES; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_KEY_CFBundleDisplayName = "Go Now"; INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.weather"; INFOPLIST_KEY_UILaunchScreen_Generation = YES; INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MARKETING_VERSION = 0.1.0; PRODUCT_BUNDLE_IDENTIFIER = com.nitbuk.gonow; PRODUCT_NAME = "$(TARGET_NAME)"; SUPPORTED_PLATFORMS = "iphoneos iphonesimulator"; SUPPORTS_MACCATALYST = NO; SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1; }; name = Release; };
+		0B000000000000000000000020 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {BUNDLE_LOADER = "$(TEST_HOST)"; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_TEAM = ""; GENERATE_INFOPLIST_FILE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MARKETING_VERSION = 0.1.0; PRODUCT_BUNDLE_IDENTIFIER = com.nitbuk.gonowTests; PRODUCT_NAME = "$(TARGET_NAME)"; SUPPORTED_PLATFORMS = "iphoneos iphonesimulator"; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1; TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GoNow.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/GoNow"; }; name = Debug; };
+		0B000000000000000000000021 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {BUNDLE_LOADER = "$(TEST_HOST)"; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_TEAM = ""; GENERATE_INFOPLIST_FILE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MARKETING_VERSION = 0.1.0; PRODUCT_BUNDLE_IDENTIFIER = com.nitbuk.gonowTests; PRODUCT_NAME = "$(TARGET_NAME)"; SUPPORTED_PLATFORMS = "iphoneos iphonesimulator"; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1; TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GoNow.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/GoNow"; }; name = Release; };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		080000000000000000000001 /* Build configuration list for PBXProject "GoNow" */ = {isa = XCConfigurationList; buildConfigurations = (0B000000000000000000000001 /* Debug */, 0B000000000000000000000002 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		080000000000000000000010 /* Build configuration list for PBXNativeTarget "GoNow" */ = {isa = XCConfigurationList; buildConfigurations = (0B000000000000000000000010 /* Debug */, 0B000000000000000000000011 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		080000000000000000000020 /* Build configuration list for PBXNativeTarget "GoNowTests" */ = {isa = XCConfigurationList; buildConfigurations = (0B000000000000000000000020 /* Debug */, 0B000000000000000000000021 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+	};
+	rootObject = 040000000000000000000001 /* Project object */;
+}

--- a/apps/ios_go_now/GoNow.xcodeproj/xcshareddata/xcschemes/GoNow.xcscheme
+++ b/apps/ios_go_now/GoNow.xcodeproj/xcshareddata/xcschemes/GoNow.xcscheme
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion="2600" version="1.7">
+   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES" buildArchitectures="Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="050000000000000000000001" BuildableName="GoNow.app" BlueprintName="GoNow" ReferencedContainer="container:GoNow.xcodeproj"></BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES" shouldAutocreateTestPlan="YES">
+      <Testables>
+         <TestableReference skipped="NO" parallelizable="YES">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="050000000000000000000002" BuildableName="GoNowTests.xctest" BlueprintName="GoNowTests" ReferencedContainer="container:GoNow.xcodeproj"></BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" debugServiceExtension="internal" allowLocationSimulation="YES">
+      <BuildableProductRunnable runnableDebuggingMode="0">
+         <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="050000000000000000000001" BuildableName="GoNow.app" BlueprintName="GoNow" ReferencedContainer="container:GoNow.xcodeproj"></BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction buildConfiguration="Release" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES">
+      <BuildableProductRunnable runnableDebuggingMode="0">
+         <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="050000000000000000000001" BuildableName="GoNow.app" BlueprintName="GoNow" ReferencedContainer="container:GoNow.xcodeproj"></BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration="Debug"></AnalyzeAction>
+   <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES"></ArchiveAction>
+</Scheme>

--- a/apps/ios_go_now/GoNow/App/AppRootView.swift
+++ b/apps/ios_go_now/GoNow/App/AppRootView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct AppRootView: View {
+    @State private var selectedTab: AppTab = .today
+    @State private var todayPath: [AppRoute] = []
+    @State private var plannerPath: [AppRoute] = []
+    @State private var profilePath: [AppRoute] = []
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            NavigationStack(path: $todayPath) {
+                TodayView()
+                    .navigationDestination(for: AppRoute.self) { routeDestination($0) }
+            }
+            .tabItem { Label(AppTab.today.title, systemImage: AppTab.today.symbolName) }
+            .tag(AppTab.today)
+
+            NavigationStack(path: $plannerPath) {
+                PlannerView()
+                    .navigationDestination(for: AppRoute.self) { routeDestination($0) }
+            }
+            .tabItem { Label(AppTab.planner.title, systemImage: AppTab.planner.symbolName) }
+            .tag(AppTab.planner)
+
+            NavigationStack(path: $profilePath) {
+                ProfileView()
+                    .navigationDestination(for: AppRoute.self) { routeDestination($0) }
+            }
+            .tabItem { Label(AppTab.profile.title, systemImage: AppTab.profile.symbolName) }
+            .tag(AppTab.profile)
+        }
+        .tint(.goNowAccent)
+    }
+
+    @ViewBuilder
+    private func routeDestination(_ route: AppRoute) -> some View {
+        switch route {
+        case .hour:
+            EmptyView()
+        case .status:
+            StatusView(client: URLSessionForecastClient.live)
+        case .formula:
+            FormulaView()
+        case .about:
+            AboutView()
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/App/AppTab.swift
+++ b/apps/ios_go_now/GoNow/App/AppTab.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+enum AppTab: String, CaseIterable, Identifiable {
+    case today
+    case planner
+    case profile
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .today: "Today"
+        case .planner: "Planner"
+        case .profile: "Profile"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .today: "sun.max.fill"
+        case .planner: "calendar"
+        case .profile: "person.crop.circle"
+        }
+    }
+}
+
+enum AppRoute: Hashable {
+    case hour(Date)
+    case status
+    case formula
+    case about
+}

--- a/apps/ios_go_now/GoNow/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/ios_go_now/GoNow/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "alpha": "1.000",
+          "blue": "0.545",
+          "green": "0.686",
+          "red": "0.078"
+        }
+      },
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios_go_now/GoNow/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apps/ios_go_now/GoNow/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "platform": "ios",
+      "size": "1024x1024"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios_go_now/GoNow/Assets.xcassets/Contents.json
+++ b/apps/ios_go_now/GoNow/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios_go_now/GoNow/DesignSystem/Components.swift
+++ b/apps/ios_go_now/GoNow/DesignSystem/Components.swift
@@ -1,0 +1,416 @@
+import SwiftUI
+
+struct AppCard<Content: View>: View {
+    let content: Content
+    var padding: CGFloat = 16
+
+    init(padding: CGFloat = 16, @ViewBuilder content: () -> Content) {
+        self.padding = padding
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(padding)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .background(Color.goNowCard, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(Color.goNowCardBorder, lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.18), radius: 20, y: 12)
+    }
+}
+
+struct GoNowScreenBackground<Content: View>: View {
+    var accentLabel: ScoreLabel?
+    let content: Content
+
+    init(accentLabel: ScoreLabel? = nil, @ViewBuilder content: () -> Content) {
+        self.accentLabel = accentLabel
+        self.content = content()
+    }
+
+    var body: some View {
+        ZStack {
+            LinearGradient.goNowBackground
+                .ignoresSafeArea()
+
+            if let accentLabel {
+                RadialGradient(
+                    colors: [Color.score(accentLabel).opacity(accentLabel.tintOpacity), .clear],
+                    center: .top,
+                    startRadius: 20,
+                    endRadius: 420
+                )
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+            }
+
+            content
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+struct SectionTitle: View {
+    let title: String
+    var trailing: String?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.goNowMutedText)
+                .textCase(.uppercase)
+                .tracking(3.2)
+            Spacer()
+            if let trailing {
+                Text(trailing)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.goNowMutedText)
+            }
+        }
+    }
+}
+
+struct ModePicker: View {
+    @Binding var selection: ActivityMode
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 0) {
+                modeButton(title: "Swim", systemImage: "water.waves", isActive: selection.isSwim) {
+                    selection = ActivityMode.composed(activityIsSwim: true, includesDog: selection.includesDog)
+                }
+
+                modeButton(title: "Run", systemImage: "figure.run", isActive: !selection.isSwim) {
+                    selection = ActivityMode.composed(activityIsSwim: false, includesDog: selection.includesDog)
+                }
+            }
+            .padding(4)
+            .background(Color.white.opacity(0.06), in: Capsule())
+            .overlay {
+                Capsule().stroke(Color.white.opacity(0.08), lineWidth: 1)
+            }
+
+            Button {
+                selection = ActivityMode.composed(activityIsSwim: selection.isSwim, includesDog: !selection.includesDog)
+            } label: {
+                Label("With Dog", systemImage: "pawprint")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(selection.includesDog ? .white : Color.goNowMutedText)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(selection.includesDog ? Color.white.opacity(0.12) : Color.white.opacity(0.035), in: Capsule())
+                    .overlay {
+                        Capsule().stroke(Color.white.opacity(selection.includesDog ? 0.16 : 0.08), lineWidth: 1)
+                    }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("With dog")
+            .accessibilityValue(selection.includesDog ? "On" : "Off")
+        }
+        .accessibilityLabel("Activity mode")
+    }
+
+    private func modeButton(title: String, systemImage: String, isActive: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(isActive ? .white : Color.goNowMutedText)
+                .frame(width: 104, height: 46)
+                .background(isActive ? Color.white.opacity(0.14) : .clear, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+}
+
+struct ScoreBadge: View {
+    let score: ModeScore
+    var size: CGFloat = 72
+
+    var body: some View {
+        Text(score.score.formatted())
+            .font(.system(size: size * 0.34, weight: .bold, design: .rounded))
+            .monospacedDigit()
+            .foregroundStyle(.white)
+            .frame(width: size, height: size)
+            .background(
+                Circle()
+                    .fill(LinearGradient.score(score.label))
+                    .shadow(color: Color.score(score.label).opacity(0.34), radius: 18, y: 8)
+            )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(score.score), \(score.label.accessibilitySummary)")
+    }
+}
+
+struct HeroScoreView: View {
+    let score: ModeScore
+    let mode: ActivityMode
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(alignment: .center, spacing: 24) {
+                ActivityGlyphs(mode: mode)
+
+                Text(score.score.formatted())
+                    .font(.system(size: 96, weight: .bold, design: .rounded))
+                    .minimumScaleFactor(0.65)
+                    .lineLimit(1)
+                    .monospacedDigit()
+                    .foregroundStyle(Color.score(score.label))
+                    .shadow(color: Color.score(score.label).opacity(0.42), radius: 32)
+                    .accessibilityLabel("\(score.score)")
+            }
+            .frame(maxWidth: .infinity)
+
+            Text(score.label.rawValue)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(Color.score(score.label))
+
+            Text(score.hardGated ? "Nope. \(score.reasons.first?.text ?? "Conditions are gated.")" : vibeLine(for: score.label))
+                .font(.system(size: 17, weight: .medium))
+                .italic()
+                .foregroundStyle(Color.goNowMutedText)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 18)
+        }
+        .padding(.top, 10)
+        .padding(.bottom, 6)
+    }
+
+    private func vibeLine(for label: ScoreLabel) -> String {
+        switch label {
+        case .perfect: "Sea glass smooth. You know what to do."
+        case .good: "Pretty good out there. A few things to know."
+        case .meh: "Could go either way. Your call."
+        case .bad: "The coast says not today. Trust it."
+        case .nope: "Somewhere between no and absolutely not."
+        }
+    }
+}
+
+struct ActivityGlyphs: View {
+    let mode: ActivityMode
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            if mode.includesDog {
+                Image(systemName: "dog.fill")
+                    .font(.system(size: 38, weight: .semibold))
+                    .offset(y: 6)
+            }
+            Image(systemName: mode.isSwim ? "figure.pool.swim" : "figure.run")
+                .font(.system(size: 62, weight: .semibold))
+        }
+        .symbolRenderingMode(.hierarchical)
+        .foregroundStyle(Color.score(.perfect))
+        .frame(width: 112, alignment: .trailing)
+        .accessibilityHidden(true)
+    }
+}
+
+struct ConditionsStrip: View {
+    let hour: ScoredHour
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ConditionMetric(systemImage: "thermometer.medium", label: "Feels", value: hour.feelslikeC.formattedMetric("°", digits: 0), severity: severity(feelsLike: hour.feelslikeC))
+            ConditionMetric(systemImage: "water.waves", label: "Waves", value: hour.waveHeightM.formattedMetric("m"), severity: severity(waves: hour.waveHeightM))
+            ConditionMetric(systemImage: "wind", label: "Wind", value: hour.windMs.formattedMetric("m/s", digits: 0), severity: severity(wind: hour.windMs))
+            ConditionMetric(systemImage: "sun.max", label: "UV", value: hour.uvIndex.formattedMetric("", digits: 0), severity: severity(uv: hour.uvIndex))
+            ConditionMetric(systemImage: "aqi.medium", label: "AQI", value: hour.euAqi.formattedMetric(""), severity: severity(aqi: hour.euAqi))
+            ConditionMetric(systemImage: "cloud.rain", label: "Rain", value: hour.precipProbPct.formattedMetric("%"), severity: severity(rain: hour.precipProbPct))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func severity(feelsLike value: Double?) -> ReasonSeverity {
+        guard let value else { return .info }
+        if value >= 30 || value <= 8 { return .danger }
+        if value >= 26 || value <= 13 { return .warning }
+        return .check
+    }
+
+    private func severity(waves value: Double?) -> ReasonSeverity {
+        guard let value else { return .info }
+        if value >= 1.2 { return .danger }
+        if value >= 0.7 { return .warning }
+        return .check
+    }
+
+    private func severity(wind value: Double?) -> ReasonSeverity {
+        guard let value else { return .info }
+        if value >= 10 { return .danger }
+        if value >= 6 { return .warning }
+        return .check
+    }
+
+    private func severity(uv value: Double?) -> ReasonSeverity {
+        guard let value else { return .info }
+        if value >= 8 { return .danger }
+        if value >= 5 { return .warning }
+        return .check
+    }
+
+    private func severity(aqi value: Int?) -> ReasonSeverity {
+        guard let value else { return .info }
+        if value >= 150 { return .danger }
+        if value >= 80 { return .warning }
+        return .check
+    }
+
+    private func severity(rain value: Int?) -> ReasonSeverity {
+        guard let value else { return .info }
+        if value >= 70 { return .danger }
+        if value >= 30 { return .warning }
+        return .check
+    }
+}
+
+struct ConditionMetric: View {
+    let systemImage: String
+    let label: String
+    let value: String
+    let severity: ReasonSeverity
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Image(systemName: systemImage)
+                .font(.system(size: 18, weight: .semibold))
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .textCase(.uppercase)
+                .tracking(1.4)
+            Text(value)
+                .font(.system(size: 18, weight: .bold))
+                .monospacedDigit()
+        }
+        .foregroundStyle(Color.reason(severity))
+        .frame(maxWidth: .infinity)
+        .minimumScaleFactor(0.72)
+    }
+}
+
+struct ReasonChipView: View {
+    let chip: ReasonChip
+
+    var body: some View {
+        Label(chip.text, systemImage: symbolName)
+            .font(.system(size: 12, weight: .semibold))
+            .lineLimit(1)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .foregroundStyle(Color.reason(chip.emoji))
+            .background(Color.reason(chip.emoji).opacity(0.13), in: Capsule())
+    }
+
+    private var symbolName: String {
+        switch chip.emoji {
+        case .check: "checkmark.circle.fill"
+        case .warning: "exclamationmark.triangle.fill"
+        case .danger: "xmark.octagon.fill"
+        case .info: "info.circle.fill"
+        }
+    }
+}
+
+struct FreshnessBadge: View {
+    let ageMinutes: Int
+
+    var body: some View {
+        let state = ForecastAnalytics.freshnessState(ageMinutes: ageMinutes)
+        HStack(spacing: 8) {
+            Circle()
+                .fill(color(for: state))
+                .frame(width: 8, height: 8)
+            Image(systemName: "clock")
+                .font(.system(size: 14, weight: .semibold))
+            Text(label)
+        }
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(color(for: state))
+            .accessibilityLabel("Updated \(label)")
+    }
+
+    private var label: String {
+        if ageMinutes < 60 { return "\(ageMinutes)m ago" }
+        return "\(Int(round(Double(ageMinutes) / 60.0)))h ago"
+    }
+
+    private func color(for state: FreshnessState) -> Color {
+        switch state {
+        case .fresh: .goNowAccent
+        case .stale: Color.reason(.warning)
+        case .veryStale: Color.reason(.danger)
+        }
+    }
+}
+
+struct LoadingRowsView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            ForEach(0..<5, id: \.self) { _ in
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.white.opacity(0.08))
+                    .frame(height: 72)
+                    .redacted(reason: .placeholder)
+            }
+        }
+        .accessibilityLabel("Loading forecast")
+    }
+}
+
+struct EmptyStateView: View {
+    let title: String
+    let message: String
+    let systemImage: String
+
+    var body: some View {
+        ContentUnavailableView(title, systemImage: systemImage, description: Text(message))
+            .foregroundStyle(.white, Color.goNowMutedText)
+    }
+}
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 0
+        var point = CGPoint.zero
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if point.x > 0, point.x + size.width > width {
+                point.x = 0
+                point.y += rowHeight + spacing
+                rowHeight = 0
+            }
+            rowHeight = max(rowHeight, size.height)
+            point.x += size.width + spacing
+        }
+        return CGSize(width: width, height: point.y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var point = bounds.origin
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if point.x > bounds.minX, point.x + size.width > bounds.maxX {
+                point.x = bounds.minX
+                point.y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: point, proposal: ProposedViewSize(size))
+            rowHeight = max(rowHeight, size.height)
+            point.x += size.width + spacing
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/DesignSystem/ScoreStyle.swift
+++ b/apps/ios_go_now/GoNow/DesignSystem/ScoreStyle.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+extension Color {
+    static let goNowAccent = Color(red: 0.13, green: 0.85, blue: 0.66)
+    static let goNowBackground = Color(red: 0.04, green: 0.06, blue: 0.11)
+    static let goNowBackgroundDeep = Color(red: 0.03, green: 0.04, blue: 0.08)
+    static let goNowCard = Color.white.opacity(0.065)
+    static let goNowCardBorder = Color.white.opacity(0.11)
+    static let goNowMutedText = Color(red: 0.57, green: 0.63, blue: 0.74)
+    static let goNowSecondaryText = Color(red: 0.76, green: 0.80, blue: 0.88)
+    static let goNowDivider = Color.white.opacity(0.07)
+
+    static func score(_ label: ScoreLabel) -> Color {
+        switch label {
+        case .perfect: .goNowAccent
+        case .good: Color(red: 0.38, green: 0.65, blue: 0.98)
+        case .meh: Color(red: 0.98, green: 0.75, blue: 0.14)
+        case .bad: Color(red: 0.98, green: 0.57, blue: 0.24)
+        case .nope: Color(red: 0.97, green: 0.44, blue: 0.44)
+        }
+    }
+
+    static func scoreAccent(_ label: ScoreLabel) -> Color {
+        switch label {
+        case .perfect: Color(red: 0.27, green: 0.91, blue: 0.74)
+        case .good: Color(red: 0.35, green: 0.82, blue: 0.96)
+        case .meh: Color(red: 1.00, green: 0.87, blue: 0.30)
+        case .bad: Color(red: 1.00, green: 0.70, blue: 0.34)
+        case .nope: Color(red: 0.98, green: 0.56, blue: 0.62)
+        }
+    }
+
+    static func reason(_ severity: ReasonSeverity) -> Color {
+        switch severity {
+        case .check: .goNowAccent
+        case .warning: Color(red: 0.98, green: 0.75, blue: 0.14)
+        case .danger: Color(red: 0.97, green: 0.44, blue: 0.44)
+        case .info: .goNowMutedText
+        }
+    }
+}
+
+extension LinearGradient {
+    static func score(_ label: ScoreLabel) -> LinearGradient {
+        LinearGradient(
+            colors: [.score(label), .scoreAccent(label)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    static let goNowBackground = LinearGradient(
+        colors: [.goNowBackgroundDeep, .goNowBackground, Color(red: 0.06, green: 0.10, blue: 0.15)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+}
+
+extension Date {
+    func goNowHour() -> String {
+        DateFormatter.goNowHour.string(from: self)
+    }
+
+    func goNowDay() -> String {
+        DateFormatter.goNowShortDay.string(from: self)
+    }
+
+    func goNowLongDay() -> String {
+        DateFormatter.goNowLongDay.string(from: self)
+    }
+
+    func goNowAPIDay() -> String {
+        DateFormatter.goNowAPIDay.string(from: self)
+    }
+}
+
+extension DateFormatter {
+    static let goNowHour: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_IL")
+        formatter.timeZone = TimeZone(identifier: "Asia/Jerusalem")
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    static let goNowShortDay: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_IL")
+        formatter.timeZone = TimeZone(identifier: "Asia/Jerusalem")
+        formatter.dateFormat = "EEE d"
+        return formatter
+    }()
+
+    static let goNowLongDay: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_IL")
+        formatter.timeZone = TimeZone(identifier: "Asia/Jerusalem")
+        formatter.dateFormat = "EEEE, MMM d"
+        return formatter
+    }()
+
+    static let goNowAPIDay: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Jerusalem")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}
+
+extension Optional where Wrapped == Double {
+    func formattedMetric(_ suffix: String, digits: Int = 1) -> String {
+        guard let value = self else { return "--" }
+        return value.formatted(.number.precision(.fractionLength(digits))) + suffix
+    }
+}
+
+extension Optional where Wrapped == Int {
+    func formattedMetric(_ suffix: String) -> String {
+        guard let value = self else { return "--" }
+        return "\(value)\(suffix)"
+    }
+}
+
+extension ActivityMode {
+    var activityTitle: String {
+        switch self {
+        case .swimSolo, .swimDog: "Swim"
+        case .runSolo, .runDog: "Run"
+        }
+    }
+
+    var isSwim: Bool {
+        switch self {
+        case .swimSolo, .swimDog: true
+        case .runSolo, .runDog: false
+        }
+    }
+
+    var includesDog: Bool {
+        switch self {
+        case .swimDog, .runDog: true
+        case .swimSolo, .runSolo: false
+        }
+    }
+
+    static func composed(activityIsSwim: Bool, includesDog: Bool) -> ActivityMode {
+        switch (activityIsSwim, includesDog) {
+        case (true, true): .swimDog
+        case (true, false): .swimSolo
+        case (false, true): .runDog
+        case (false, false): .runSolo
+        }
+    }
+}
+
+extension ScoreLabel {
+    var tintOpacity: Double {
+        switch self {
+        case .perfect, .good: 0.18
+        case .meh, .bad, .nope: 0.13
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/Domain/ForecastAnalytics.swift
+++ b/apps/ios_go_now/GoNow/Domain/ForecastAnalytics.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+struct BestWindow: Hashable {
+    let startHour: ScoredHour
+    let endHour: ScoredHour
+    let averageScore: Int
+    let label: ScoreLabel
+    let lengthHours: Int
+}
+
+struct DayForecast: Identifiable, Hashable {
+    var id: Date { startOfDay }
+    let startOfDay: Date
+    let title: String
+    let hours: [ScoredHour]
+
+    func bestScore(for mode: ActivityMode) -> ModeScore? {
+        hours.max { $0.scores[mode].score < $1.scores[mode].score }?.scores[mode]
+    }
+
+    func bestHour(for mode: ActivityMode) -> ScoredHour? {
+        hours.max { $0.scores[mode].score < $1.scores[mode].score }
+    }
+}
+
+enum ForecastAnalytics {
+    static let goNowCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Jerusalem") ?? .current
+        return calendar
+    }()
+
+    static func currentHour(in forecast: ScoredForecast, now: Date = .now) -> ScoredHour? {
+        forecast.hours.last { $0.hourUtc <= now } ?? forecast.hours.first
+    }
+
+    static func upcomingHours(in forecast: ScoredForecast, now: Date = .now, limit: Int = 6) -> [ScoredHour] {
+        forecast.hours.filter { $0.hourUtc >= now }.prefix(limit).map { $0 }
+    }
+
+    static func nextDayHours(in forecast: ScoredForecast, now: Date = .now) -> [ScoredHour] {
+        let lowerBound = now.addingTimeInterval(-3600)
+        let upperBound = now.addingTimeInterval(24 * 3600)
+        return forecast.hours.filter { $0.hourUtc >= lowerBound && $0.hourUtc <= upperBound }
+    }
+
+    static func bestWindow(in forecast: ScoredForecast, mode: ActivityMode, now: Date = .now) -> BestWindow? {
+        let futureHours = forecast.hours.filter { $0.hourUtc > now }
+        var bestStart: Int?
+        var bestEnd: Int?
+        var bestAverage = 0.0
+        var currentStart: Int?
+
+        for index in 0...futureHours.count {
+            let score = index < futureHours.count ? futureHours[index].scores[mode].score : 0
+            if score >= 70 {
+                currentStart = currentStart ?? index
+            } else if let start = currentStart {
+                let window = futureHours[start..<index]
+                let average = Double(window.map { $0.scores[mode].score }.reduce(0, +)) / Double(window.count)
+                if average > bestAverage {
+                    bestStart = start
+                    bestEnd = index - 1
+                    bestAverage = average
+                }
+                currentStart = nil
+            }
+        }
+
+        guard let bestStart, let bestEnd else { return nil }
+        let averageScore = Int(bestAverage.rounded())
+        return BestWindow(
+            startHour: futureHours[bestStart],
+            endHour: futureHours[bestEnd],
+            averageScore: averageScore,
+            label: ScoreLabel.label(for: averageScore),
+            lengthHours: bestEnd - bestStart + 1
+        )
+    }
+
+    static func days(in forecast: ScoredForecast, now: Date = .now) -> [DayForecast] {
+        let grouped = Dictionary(grouping: forecast.hours) { hour in
+            goNowCalendar.startOfDay(for: hour.hourUtc)
+        }
+
+        return grouped.keys.sorted().map { startOfDay in
+            DayForecast(
+                startOfDay: startOfDay,
+                title: dayTitle(for: startOfDay, now: now),
+                hours: grouped[startOfDay, default: []].sorted { $0.hourUtc < $1.hourUtc }
+            )
+        }
+    }
+
+    static func freshnessState(ageMinutes: Int) -> FreshnessState {
+        if ageMinutes < 90 { return .fresh }
+        if ageMinutes < 180 { return .stale }
+        return .veryStale
+    }
+
+    static func dayTitle(for day: Date, now: Date = .now) -> String {
+        let calendar = goNowCalendar
+        if calendar.isDate(day, inSameDayAs: now) { return "Today" }
+        if calendar.isDate(day, inSameDayAs: calendar.date(byAdding: .day, value: 1, to: now) ?? now) {
+            return "Tomorrow"
+        }
+        return DateFormatter.goNowDayTitle.string(from: day)
+    }
+}
+
+enum FreshnessState {
+    case fresh
+    case stale
+    case veryStale
+}
+
+extension DateFormatter {
+    static let goNowDayTitle: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_IL")
+        formatter.timeZone = TimeZone(identifier: "Asia/Jerusalem")
+        formatter.dateFormat = "EEEE MMM d"
+        return formatter
+    }()
+}

--- a/apps/ios_go_now/GoNow/Domain/ForecastMetric.swift
+++ b/apps/ios_go_now/GoNow/Domain/ForecastMetric.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+enum ForecastMetric: String, CaseIterable, Identifiable {
+    case score
+    case temperature
+    case uv
+    case wind
+    case waves
+    case rain
+    case aqi
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .score: "Score"
+        case .temperature: "Temperature"
+        case .uv: "UV Index"
+        case .wind: "Wind"
+        case .waves: "Waves"
+        case .rain: "Rain"
+        case .aqi: "Air Quality"
+        }
+    }
+
+    var compactLabel: String {
+        switch self {
+        case .temperature: "Temp"
+        case .uv: "UV"
+        case .aqi: "AQI"
+        default: label
+        }
+    }
+
+    var unit: String {
+        switch self {
+        case .score, .uv, .aqi: ""
+        case .temperature: "°"
+        case .wind: "m/s"
+        case .waves: "m"
+        case .rain: "%"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .score: "waveform.path.ecg"
+        case .temperature: "thermometer.medium"
+        case .uv: "sun.max"
+        case .wind: "wind"
+        case .waves: "water.waves"
+        case .rain: "cloud.rain"
+        case .aqi: "aqi.medium"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .score: .score(.good)
+        case .temperature: Color.reason(.danger)
+        case .uv: Color.reason(.warning)
+        case .wind: .goNowAccent
+        case .waves: .score(.good)
+        case .rain: Color(red: 0.65, green: 0.55, blue: 0.98)
+        case .aqi: Color(red: 0.97, green: 0.44, blue: 0.44)
+        }
+    }
+
+    func value(in hour: ScoredHour, mode: ActivityMode) -> Double? {
+        switch self {
+        case .score: Double(hour.scores[mode].score)
+        case .temperature: hour.feelslikeC
+        case .uv: hour.uvIndex
+        case .wind: hour.windMs
+        case .waves: hour.waveHeightM
+        case .rain: hour.precipProbPct.map(Double.init)
+        case .aqi: hour.euAqi.map(Double.init)
+        }
+    }
+
+    func formatted(_ value: Double?) -> String {
+        guard let value else { return "--" }
+        switch self {
+        case .waves:
+            return value.formatted(.number.precision(.fractionLength(1))) + unit
+        default:
+            return Int(value.rounded()).formatted() + unit
+        }
+    }
+}
+
+struct DayMetricSummary: Hashable {
+    let min: Double
+    let max: Double
+    let bestScore: Int
+    let bestLabel: ScoreLabel
+    let bestHour: ScoredHour?
+}
+
+extension DayForecast {
+    func metricSummary(for metric: ForecastMetric, mode: ActivityMode) -> DayMetricSummary {
+        let values = hours.compactMap { metric.value(in: $0, mode: mode) }
+        let scores = hours.map { $0.scores[mode].score }
+        let bestHour = self.bestHour(for: mode)
+        let bestScore = scores.max() ?? 0
+
+        return DayMetricSummary(
+            min: values.min() ?? 0,
+            max: values.max() ?? 0,
+            bestScore: bestScore,
+            bestLabel: ScoreLabel.label(for: bestScore),
+            bestHour: bestHour
+        )
+    }
+}

--- a/apps/ios_go_now/GoNow/Domain/HealthModels.swift
+++ b/apps/ios_go_now/GoNow/Domain/HealthModels.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+enum SystemHealthStatus: String, Decodable {
+    case healthy
+    case degraded
+    case unhealthy
+}
+
+enum ForecastFreshness: String, Decodable {
+    case fresh
+    case stale
+}
+
+struct HealthForecast: Decodable, Hashable {
+    let areaId: String
+    let updatedAtUtc: Date?
+    let ageMinutes: Int
+    let freshness: ForecastFreshness
+    let ingestStatus: String
+    let hoursCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case areaId = "area_id"
+        case updatedAtUtc = "updated_at_utc"
+        case ageMinutes = "age_minutes"
+        case freshness
+        case ingestStatus = "ingest_status"
+        case hoursCount = "hours_count"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        areaId = try container.decode(String.self, forKey: .areaId)
+        ageMinutes = try container.decode(Int.self, forKey: .ageMinutes)
+        freshness = try container.decode(ForecastFreshness.self, forKey: .freshness)
+        ingestStatus = try container.decode(String.self, forKey: .ingestStatus)
+        hoursCount = try container.decode(Int.self, forKey: .hoursCount)
+
+        let updatedString = try container.decode(String.self, forKey: .updatedAtUtc)
+        if updatedString.isEmpty {
+            updatedAtUtc = nil
+        } else if let parsed = GoNowDateParser.parse(updatedString) {
+            updatedAtUtc = parsed
+        } else {
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: decoder.codingPath + [CodingKeys.updatedAtUtc], debugDescription: "Invalid ISO-8601 date: \(updatedString)")
+            )
+        }
+    }
+}
+
+struct HealthResponse: Decodable, Hashable {
+    let status: SystemHealthStatus
+    let version: String
+    let scoringVersion: String
+    let forecast: HealthForecast
+    let timestampUtc: Date
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case version
+        case scoringVersion = "scoring_version"
+        case forecast
+        case timestampUtc = "timestamp_utc"
+    }
+}

--- a/apps/ios_go_now/GoNow/Domain/Models.swift
+++ b/apps/ios_go_now/GoNow/Domain/Models.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+enum ActivityMode: String, CaseIterable, Codable, Identifiable {
+    case swimSolo = "swim_solo"
+    case swimDog = "swim_dog"
+    case runSolo = "run_solo"
+    case runDog = "run_dog"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .swimSolo: "Swim"
+        case .swimDog: "Swim + Dog"
+        case .runSolo: "Run"
+        case .runDog: "Run + Dog"
+        }
+    }
+
+    var compactTitle: String {
+        switch self {
+        case .swimSolo: "Swim"
+        case .swimDog: "Dog swim"
+        case .runSolo: "Run"
+        case .runDog: "Dog run"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .swimSolo: "figure.pool.swim"
+        case .swimDog: "pawprint.fill"
+        case .runSolo: "figure.run"
+        case .runDog: "figure.walk.motion"
+        }
+    }
+}
+
+enum ScoreLabel: String, CaseIterable, Codable {
+    case perfect = "Perfect"
+    case good = "Good"
+    case meh = "Meh"
+    case bad = "Bad"
+    case nope = "Nope"
+
+    var accessibilitySummary: String {
+        switch self {
+        case .perfect: "Perfect conditions"
+        case .good: "Good conditions"
+        case .meh: "Mixed conditions"
+        case .bad: "Poor conditions"
+        case .nope: "Not recommended"
+        }
+    }
+
+    static func label(for score: Int) -> ScoreLabel {
+        switch score {
+        case 85...100: .perfect
+        case 70..<85: .good
+        case 45..<70: .meh
+        case 20..<45: .bad
+        default: .nope
+        }
+    }
+}
+
+enum ReasonSeverity: String, Codable {
+    case check
+    case warning
+    case danger
+    case info
+}
+
+struct ReasonChip: Decodable, Hashable, Identifiable {
+    var id: String { "\(factor)-\(text)-\(penalty)" }
+    let factor: String
+    let text: String
+    let emoji: ReasonSeverity
+    let penalty: Int
+}
+
+struct ModeScore: Decodable, Hashable {
+    let score: Int
+    let label: ScoreLabel
+    let reasons: [ReasonChip]
+    let hardGated: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case score
+        case label
+        case reasons
+        case hardGated = "hard_gated"
+    }
+}
+
+struct ModeScores: Decodable, Hashable {
+    let swimSolo: ModeScore
+    let swimDog: ModeScore
+    let runSolo: ModeScore
+    let runDog: ModeScore
+
+    enum CodingKeys: String, CodingKey {
+        case swimSolo = "swim_solo"
+        case swimDog = "swim_dog"
+        case runSolo = "run_solo"
+        case runDog = "run_dog"
+    }
+
+    subscript(mode: ActivityMode) -> ModeScore {
+        switch mode {
+        case .swimSolo: swimSolo
+        case .swimDog: swimDog
+        case .runSolo: runSolo
+        case .runDog: runDog
+        }
+    }
+}
+
+struct ScoredHour: Decodable, Hashable, Identifiable {
+    var id: Date { hourUtc }
+
+    let hourUtc: Date
+    let waveHeightM: Double?
+    let wavePeriodS: Double?
+    let airTempC: Double?
+    let feelslikeC: Double?
+    let windMs: Double?
+    let gustMs: Double?
+    let precipProbPct: Int?
+    let precipMm: Double?
+    let uvIndex: Double?
+    let euAqi: Int?
+    let pm10: Double?
+    let pm25: Double?
+    let scores: ModeScores
+
+    enum CodingKeys: String, CodingKey {
+        case hourUtc = "hour_utc"
+        case waveHeightM = "wave_height_m"
+        case wavePeriodS = "wave_period_s"
+        case airTempC = "air_temp_c"
+        case feelslikeC = "feelslike_c"
+        case windMs = "wind_ms"
+        case gustMs = "gust_ms"
+        case precipProbPct = "precip_prob_pct"
+        case precipMm = "precip_mm"
+        case uvIndex = "uv_index"
+        case euAqi = "eu_aqi"
+        case pm10
+        case pm25 = "pm2_5"
+        case scores
+    }
+}
+
+struct DailySunTime: Decodable, Hashable, Identifiable {
+    var id: String { date }
+    let date: String
+    let sunriseUtc: Date
+    let sunsetUtc: Date
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case sunriseUtc = "sunrise_utc"
+        case sunsetUtc = "sunset_utc"
+    }
+}
+
+struct ScoredForecast: Decodable, Hashable {
+    let areaId: String
+    let updatedAtUtc: Date
+    let provider: String
+    let freshness: String
+    let forecastAgeMinutes: Int
+    let horizonDays: Int
+    let scoringVersion: String
+    let hours: [ScoredHour]
+    let daily: [DailySunTime]
+
+    enum CodingKeys: String, CodingKey {
+        case areaId = "area_id"
+        case updatedAtUtc = "updated_at_utc"
+        case provider
+        case freshness
+        case forecastAgeMinutes = "forecast_age_minutes"
+        case horizonDays = "horizon_days"
+        case scoringVersion = "scoring_version"
+        case hours
+        case daily
+    }
+}
+
+extension JSONDecoder {
+    static var goNowAPI: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let value = try decoder.singleValueContainer().decode(String.self)
+            if let date = GoNowDateParser.parse(value) {
+                return date
+            }
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: decoder.codingPath, debugDescription: "Invalid ISO-8601 date: \(value)")
+            )
+        }
+        return decoder
+    }
+}
+
+enum GoNowDateParser {
+    static func parse(_ value: String) -> Date? {
+        DateFormatter.goNowMicroseconds.date(from: value)
+            ?? DateFormatter.goNowMilliseconds.date(from: value)
+            ?? ISO8601DateFormatter.goNowFractional.date(from: value)
+            ?? ISO8601DateFormatter.goNow.date(from: value)
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let goNow: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static let goNowFractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}
+
+private extension DateFormatter {
+    static let goNowMicroseconds: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX"
+        return formatter
+    }()
+
+    static let goNowMilliseconds: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        return formatter
+    }()
+}

--- a/apps/ios_go_now/GoNow/Features/ForecastDetails/DayDetailSheet.swift
+++ b/apps/ios_go_now/GoNow/Features/ForecastDetails/DayDetailSheet.swift
@@ -1,0 +1,269 @@
+import Charts
+import SwiftUI
+
+struct DayDetailSheet: View {
+    let day: DayForecast
+    let forecast: ScoredForecast
+    let mode: ActivityMode
+    let initialMetric: ForecastMetric
+    @State private var selectedMetric: ForecastMetric
+
+    init(day: DayForecast, forecast: ScoredForecast, mode: ActivityMode, initialMetric: ForecastMetric = .score) {
+        self.day = day
+        self.forecast = forecast
+        self.mode = mode
+        self.initialMetric = initialMetric
+        _selectedMetric = State(initialValue: initialMetric)
+    }
+
+    var body: some View {
+        NavigationStack {
+            GoNowScreenBackground(accentLabel: summary.bestLabel) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        header
+                        metricMenu
+                        metricChart
+                        hourlyRows
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 16)
+                    .padding(.bottom, 30)
+                }
+            }
+            .navigationTitle(day.title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private var summary: DayMetricSummary {
+        day.metricSummary(for: selectedMetric, mode: mode)
+    }
+
+    private var points: [MetricChartPoint] {
+        day.hours.compactMap { hour in
+            guard let value = selectedMetric.value(in: hour, mode: mode) else { return nil }
+            return MetricChartPoint(hour: hour.hourUtc, value: value, label: hour.scores[mode].label)
+        }
+    }
+
+    private var sunTimes: DailySunTime? {
+        let key = day.startOfDay.goNowAPIDay()
+        return forecast.daily.first { $0.date == key }
+    }
+
+    private var header: some View {
+        AppCard {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(day.startOfDay.goNowLongDay())
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundStyle(.white)
+                    if let bestHour = summary.bestHour {
+                        Text("Best: \(summary.bestScore) at \(bestHour.hourUtc.goNowHour())")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(Color.goNowMutedText)
+                    }
+                }
+                Spacer()
+                ScoreBadge(score: summary.bestHour?.scores[mode] ?? fallbackScore, size: 66)
+            }
+        }
+    }
+
+    private var fallbackScore: ModeScore {
+        ModeScore(score: summary.bestScore, label: summary.bestLabel, reasons: [], hardGated: false)
+    }
+
+    private var metricMenu: some View {
+        Menu {
+            ForEach(ForecastMetric.allCases) { metric in
+                Button {
+                    selectedMetric = metric
+                } label: {
+                    Label(metric.label, systemImage: metric.symbolName)
+                }
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: selectedMetric.symbolName)
+                    .foregroundStyle(selectedMetric.color)
+                Text(selectedMetric.label)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color.goNowSecondaryText)
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Color.goNowMutedText)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 13)
+            .background(Color.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.white.opacity(0.09), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Metric")
+        .accessibilityValue(selectedMetric.label)
+    }
+
+    @ViewBuilder
+    private var metricChart: some View {
+        AppCard(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                SectionTitle(title: selectedMetric.label, trailing: "\(selectedMetric.formatted(summary.min))-\(selectedMetric.formatted(summary.max))")
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 18)
+                Divider().overlay(Color.goNowDivider)
+
+                if points.isEmpty {
+                    Text("No data available")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.goNowMutedText)
+                        .frame(maxWidth: .infinity, minHeight: 220)
+                } else {
+                    Chart {
+                        ForEach(points) { point in
+                            AreaMark(
+                                x: .value("Hour", point.hour),
+                                y: .value(selectedMetric.label, point.value)
+                            )
+                            .foregroundStyle(
+                                LinearGradient(
+                                    colors: [selectedMetric.color.opacity(0.28), selectedMetric.color.opacity(0.02)],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                )
+                            )
+
+                            LineMark(
+                                x: .value("Hour", point.hour),
+                                y: .value(selectedMetric.label, point.value)
+                            )
+                            .foregroundStyle(selectedMetric.color)
+                            .lineStyle(.init(lineWidth: 3, lineCap: .round, lineJoin: .round))
+
+                            PointMark(
+                                x: .value("Hour", point.hour),
+                                y: .value(selectedMetric.label, point.value)
+                            )
+                            .foregroundStyle(selectedMetric == .score ? Color.score(point.label) : selectedMetric.color)
+                        }
+
+                        if let sunTimes {
+                            RuleMark(x: .value("Sunrise", sunTimes.sunriseUtc))
+                                .foregroundStyle(Color.reason(.warning).opacity(0.55))
+                                .lineStyle(.init(lineWidth: 1, dash: [4, 4]))
+                                .annotation(position: .top, alignment: .leading) {
+                                    sunAnnotation("sunrise", sunTimes.sunriseUtc.goNowHour(), color: Color.reason(.warning))
+                                }
+
+                            RuleMark(x: .value("Sunset", sunTimes.sunsetUtc))
+                                .foregroundStyle(Color.reason(.danger).opacity(0.5))
+                                .lineStyle(.init(lineWidth: 1, dash: [4, 4]))
+                                .annotation(position: .top, alignment: .trailing) {
+                                    sunAnnotation("sunset", sunTimes.sunsetUtc.goNowHour(), color: Color.reason(.danger))
+                                }
+                        }
+                    }
+                    .chartXAxis {
+                        AxisMarks(values: .stride(by: .hour, count: 3)) { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.04))
+                            AxisValueLabel(format: .dateTime.hour(.twoDigits(amPM: .omitted)))
+                                .foregroundStyle(Color.goNowMutedText)
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks(position: .trailing) { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.05))
+                            AxisValueLabel()
+                                .foregroundStyle(Color.goNowMutedText)
+                        }
+                    }
+                    .frame(height: 230)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 18)
+                }
+            }
+        }
+    }
+
+    private func sunAnnotation(_ image: String, _ text: String, color: Color) -> some View {
+        Label(text, systemImage: image)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(Color.goNowBackground.opacity(0.8), in: Capsule())
+    }
+
+    private var hourlyRows: some View {
+        AppCard(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                SectionTitle(title: "Hourly Detail", trailing: mode.activityTitle)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 18)
+                Divider().overlay(Color.goNowDivider)
+
+                ForEach(day.hours) { hour in
+                    NavigationLink {
+                        HourDetailContent(hour: hour, mode: mode)
+                    } label: {
+                        DayMetricHourRow(hour: hour, mode: mode, metric: selectedMetric)
+                            .padding(.horizontal, 18)
+                    }
+                    .buttonStyle(.plain)
+
+                    if hour.id != day.hours.last?.id {
+                        Divider()
+                            .overlay(Color.goNowDivider)
+                            .padding(.leading, 74)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct MetricChartPoint: Identifiable {
+    var id: Date { hour }
+    let hour: Date
+    let value: Double
+    let label: ScoreLabel
+}
+
+struct DayMetricHourRow: View {
+    let hour: ScoredHour
+    let mode: ActivityMode
+    let metric: ForecastMetric
+
+    var body: some View {
+        let score = hour.scores[mode]
+        HStack(spacing: 12) {
+            ScoreBadge(score: score, size: 38)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(hour.hourUtc.goNowHour())
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.goNowSecondaryText)
+                Text(score.reasons.first?.text ?? score.label.rawValue)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(Color.goNowMutedText)
+                    .lineLimit(1)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(metric.formatted(metric.value(in: hour, mode: mode)))
+                    .font(.system(size: 17, weight: .bold, design: .rounded))
+                    .foregroundStyle(metric == .score ? Color.score(score.label) : metric.color)
+                    .monospacedDigit()
+                Text(metric.compactLabel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.goNowMutedText)
+            }
+        }
+        .padding(.vertical, 11)
+        .opacity(score.hardGated ? 0.55 : 1)
+    }
+}

--- a/apps/ios_go_now/GoNow/Features/Planner/PlannerView.swift
+++ b/apps/ios_go_now/GoNow/Features/Planner/PlannerView.swift
@@ -1,0 +1,266 @@
+import SwiftUI
+
+struct PlannerView: View {
+    @EnvironmentObject private var store: ForecastStore
+    @AppStorage("defaultMode") private var defaultModeRawValue = ActivityMode.swimSolo.rawValue
+    @State private var selectedMode: ActivityMode = .swimSolo
+    @State private var selectedHour: ScoredHour?
+    @State private var selectedDay: DayForecast?
+    @State private var expandedDays: Set<Date> = []
+
+    var body: some View {
+        GoNowScreenBackground(accentLabel: accentLabel) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    ModePicker(selection: $selectedMode)
+                    content
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 28)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
+        .refreshable { await store.refresh() }
+        .task {
+            selectedMode = ActivityMode(rawValue: defaultModeRawValue) ?? .swimSolo
+            await store.loadIfNeeded()
+        }
+        .sheet(item: $selectedHour) { hour in
+            HourDetailSheet(hour: hour, mode: selectedMode)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(item: $selectedDay) { day in
+            if let forecast = store.forecast {
+                DayDetailSheet(day: day, forecast: forecast, mode: selectedMode, initialMetric: .score)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+    }
+
+    private var accentLabel: ScoreLabel? {
+        guard let forecast = store.forecast,
+              let currentHour = ForecastAnalytics.currentHour(in: forecast) else { return nil }
+        return currentHour.scores[selectedMode].label
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Planner")
+                .font(.system(size: 32, weight: .bold))
+                .foregroundStyle(.white)
+            Spacer()
+            if let forecast = store.forecast {
+                FreshnessBadge(ageMinutes: forecast.forecastAgeMinutes)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch store.state {
+        case .idle, .loading:
+            LoadingRowsView()
+        case .loaded(let forecast), .refreshing(let forecast):
+            forecastSections(forecast)
+        case .failed(let message, let cached):
+            if let cached {
+                warningBanner("Offline. Showing last known forecast. \(message)")
+                forecastSections(cached)
+            } else {
+                EmptyStateView(title: "Could not load forecast", message: message, systemImage: "wifi.exclamationmark")
+            }
+        }
+    }
+
+    private func forecastSections(_ forecast: ScoredForecast) -> some View {
+        let days = ForecastAnalytics.days(in: forecast)
+        return AppCard(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                SectionTitle(title: "7-Day Forecast", trailing: selectedMode.activityTitle)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 18)
+                Divider().overlay(Color.goNowDivider)
+
+                ForEach(days) { day in
+                    VStack(spacing: 0) {
+                        HStack(spacing: 10) {
+                            Button {
+                                toggle(day)
+                            } label: {
+                                DayPlannerHeader(day: day, mode: selectedMode, isExpanded: shouldExpand(day: day, allDays: days))
+                            }
+                            .buttonStyle(.plain)
+
+                            Button {
+                                selectedDay = day
+                            } label: {
+                                Image(systemName: "chart.xyaxis.line")
+                                    .font(.system(size: 15, weight: .bold))
+                                    .foregroundStyle(Color.goNowAccent)
+                                    .frame(width: 38, height: 38)
+                                    .background(Color.goNowAccent.opacity(0.13), in: Circle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Open \(day.title) detail")
+                        }
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 16)
+
+                        if shouldExpand(day: day, allDays: days) {
+                            VStack(spacing: 0) {
+                                ForEach(day.hours) { hour in
+                                    HourSummaryRow(hour: hour, mode: selectedMode)
+                                        .padding(.horizontal, 18)
+                                        .contentShape(Rectangle())
+                                        .onTapGesture { selectedHour = hour }
+                                    if hour.id != day.hours.last?.id {
+                                        Divider()
+                                            .overlay(Color.goNowDivider)
+                                            .padding(.leading, 74)
+                                    }
+                                }
+                            }
+                            .padding(.bottom, 8)
+                        }
+
+                        if day.id != days.last?.id {
+                            Divider().overlay(Color.goNowDivider)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func shouldExpand(day: DayForecast, allDays: [DayForecast]) -> Bool {
+        expandedDays.contains(day.startOfDay) || allDays.prefix(2).contains(day)
+    }
+
+    private func toggle(_ day: DayForecast) {
+        if expandedDays.contains(day.startOfDay) {
+            expandedDays.remove(day.startOfDay)
+        } else {
+            expandedDays.insert(day.startOfDay)
+        }
+    }
+
+    private func warningBanner(_ message: String) -> some View {
+        Label(message, systemImage: "wifi.slash")
+            .font(.footnote)
+            .foregroundStyle(Color.reason(.warning))
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.reason(.warning).opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+struct HourDetailSheet: View {
+    let hour: ScoredHour
+    let mode: ActivityMode
+
+    var body: some View {
+        NavigationStack {
+            HourDetailContent(hour: hour, mode: mode)
+        }
+    }
+}
+
+struct HourDetailContent: View {
+    let hour: ScoredHour
+    let mode: ActivityMode
+
+    var body: some View {
+        let score = hour.scores[mode]
+        GoNowScreenBackground(accentLabel: score.label) {
+            ScrollView {
+                VStack(spacing: 20) {
+                    HeroScoreView(score: score, mode: mode)
+                        .padding(.top, 10)
+
+                    ConditionsStrip(hour: hour)
+                        .padding(.horizontal)
+
+                    FlowLayout(spacing: 8) {
+                        ForEach(score.reasons.prefix(6)) { chip in
+                            ReasonChipView(chip: chip)
+                        }
+                    }
+                    .padding(.horizontal)
+
+                    AppCard {
+                        VStack(spacing: 0) {
+                            rawRow("Wave height", hour.waveHeightM.formattedMetric(" m"))
+                            rawRow("Wind gusts", hour.gustMs.formattedMetric(" m/s"))
+                            rawRow("Feels like", hour.feelslikeC.formattedMetric(" C", digits: 0))
+                            rawRow("UV index", hour.uvIndex.formattedMetric("", digits: 0))
+                            rawRow("Air quality", hour.euAqi.formattedMetric(""))
+                            rawRow("Rain probability", hour.precipProbPct.formattedMetric("%"))
+                            rawRow("Rain amount", hour.precipMm.formattedMetric(" mm"))
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+                .padding(.bottom, 28)
+            }
+        }
+        .navigationTitle("\(mode.title) at \(hour.hourUtc.goNowHour())")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func rawRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(Color.goNowMutedText)
+            Spacer()
+            Text(value)
+                .fontWeight(.semibold)
+                .monospacedDigit()
+                .foregroundStyle(Color.goNowSecondaryText)
+        }
+        .font(.subheadline)
+        .padding(.vertical, 10)
+    }
+}
+
+struct DayPlannerHeader: View {
+    let day: DayForecast
+    let mode: ActivityMode
+    let isExpanded: Bool
+
+    var body: some View {
+        let bestHour = day.bestHour(for: mode)
+        let bestScore = day.bestScore(for: mode)
+        let label = bestScore?.label ?? .meh
+
+        HStack(spacing: 14) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(day.title)
+                    .font(.system(size: 19, weight: .bold))
+                    .foregroundStyle(Color.goNowSecondaryText)
+                if let bestHour, let bestScore {
+                    Text("Best: \(bestScore.score) at \(bestHour.hourUtc.goNowHour())")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.goNowMutedText)
+                }
+            }
+
+            Spacer()
+
+            if let bestScore {
+                Text("\(bestScore.score)")
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .foregroundStyle(Color.score(label))
+                    .monospacedDigit()
+            }
+
+            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(Color.goNowMutedText)
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/Features/Profile/AboutView.swift
+++ b/apps/ios_go_now/GoNow/Features/Profile/AboutView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct AboutView: View {
+    var body: some View {
+        GoNowScreenBackground(accentLabel: .perfect) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    Text("About")
+                        .font(.system(size: 32, weight: .bold))
+                        .foregroundStyle(.white)
+
+                    AppCard {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("One answer for the Tel Aviv coast.")
+                                .font(.system(size: 26, weight: .bold))
+                                .foregroundStyle(.white)
+                            Text("GoNow combines waves, weather, UV, rain, wind, and air quality into hourly swim and run scores for solo outings or dog-friendly plans.")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(Color.goNowMutedText)
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "Data Sources")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            aboutRow("Open-Meteo", "Marine, weather, UV, rain, wind, and temperature forecasts.")
+                            aboutRow("AQICN", "Ground air-quality readings for the Tel Aviv area.")
+                            aboutRow("GoNow API", "Backend scoring and public forecast contract.", showDivider: false)
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "First iOS Release")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            aboutRow("Native first", "The iOS app is now the primary product experience.")
+                            aboutRow("Backend scoring", "Scoring remains API-owned for maintainability.")
+                            aboutRow("Web app", "Kept working as a public demo and status surface.", showDivider: false)
+                        }
+                    }
+
+                    AppCard {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Link(destination: URL(string: "https://go-now.dev")!) {
+                                Label("Open go-now.dev", systemImage: "safari")
+                            }
+                            Link(destination: URL(string: "https://github.com/NitBuk/go-now")!) {
+                                Label("View on GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                            }
+                        }
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.goNowAccent)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 28)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func aboutRow(_ title: String, _ detail: String, showDivider: Bool = true) -> some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.goNowSecondaryText)
+                Text(detail)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(Color.goNowMutedText)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 14)
+
+            if showDivider {
+                Divider().overlay(Color.goNowDivider)
+            }
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/Features/Profile/FormulaView.swift
+++ b/apps/ios_go_now/GoNow/Features/Profile/FormulaView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct FormulaView: View {
+    var body: some View {
+        GoNowScreenBackground(accentLabel: .good) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    Text("Formula")
+                        .font(.system(size: 32, weight: .bold))
+                        .foregroundStyle(.white)
+
+                    AppCard {
+                        VStack(alignment: .leading, spacing: 12) {
+                            SectionTitle(title: "How Scores Work")
+                            Text("Score = 100 - penalties")
+                                .font(.system(size: 24, weight: .bold, design: .rounded))
+                                .foregroundStyle(.white)
+                            Text("The iOS app reads backend-computed scores from the public API. It does not recompute scoring locally in this release.")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(Color.goNowMutedText)
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "Score Tiers")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            ForEach(scoreTiers) { tier in
+                                formulaRow(tier.range, title: tier.label.rawValue, detail: tier.detail, color: Color.score(tier.label))
+                            }
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "Hard Gates")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            formulaRow("Rain", title: "Heavy rain or high rain probability", detail: "All modes can be forced to Nope.", color: Color.reason(.danger))
+                            formulaRow("Wind", title: "Very gusty run conditions", detail: "Run modes are gated when gusts are too high.", color: Color.reason(.warning))
+                            formulaRow("Darkness", title: "No night swimming", detail: "Swim scores ramp down after sunset and then gate.", color: Color.score(.good))
+                            formulaRow("Dog Heat", title: "Unsafe dog run heat", detail: "Run + Dog can be forced to Nope when heat or heat plus UV is unsafe.", color: Color.reason(.danger), showDivider: false)
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "Mode Logic")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            formulaRow("Swim", title: "Waves, rain, UV, AQI, wind, temperature", detail: "Dog swim is stricter on waves.", color: Color.score(.good))
+                            formulaRow("Run", title: "Feels-like temperature, UV, AQI, gusts, rain", detail: "Dog run is stricter for heat, UV, and air quality.", color: Color.reason(.warning))
+                            formulaRow("Dog", title: "1.2x penalty multiplier", detail: "Heat, UV, and AQI penalties are amplified for dog modes.", color: Color.reason(.danger), showDivider: false)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 28)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var scoreTiers: [ScoreTier] {
+        [
+            .init(range: "85-100", label: .perfect, detail: "Ideal conditions. Go now."),
+            .init(range: "70-84", label: .good, detail: "Good conditions with minor trade-offs."),
+            .init(range: "45-69", label: .meh, detail: "Mixed conditions. Check details."),
+            .init(range: "20-44", label: .bad, detail: "Uncomfortable or potentially unsafe."),
+            .init(range: "0-19", label: .nope, detail: "Not recommended.")
+        ]
+    }
+
+    private func formulaRow(_ leading: String, title: String, detail: String, color: Color, showDivider: Bool = true) -> some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 14) {
+                Text(leading)
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .foregroundStyle(color)
+                    .frame(width: 72, alignment: .leading)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.goNowSecondaryText)
+                    Text(detail)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(Color.goNowMutedText)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 14)
+
+            if showDivider {
+                Divider().overlay(Color.goNowDivider)
+            }
+        }
+    }
+}
+
+struct ScoreTier: Identifiable {
+    var id: String { range }
+    let range: String
+    let label: ScoreLabel
+    let detail: String
+}

--- a/apps/ios_go_now/GoNow/Features/Profile/ProfileView.swift
+++ b/apps/ios_go_now/GoNow/Features/Profile/ProfileView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @AppStorage("defaultMode") private var defaultModeRawValue = ActivityMode.swimSolo.rawValue
+    @AppStorage("analyticsOptIn") private var analyticsOptIn = true
+
+    var body: some View {
+        GoNowScreenBackground(accentLabel: .perfect) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    Text("Profile")
+                        .font(.system(size: 32, weight: .bold))
+                        .foregroundStyle(.white)
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "First Release")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            profileRow("Product focus", "Native forecast parity")
+                            profileRow("Scoring", "Backend API")
+                            profileRow("Account", "Deferred")
+                            profileRow("Notifications", "Deferred", showDivider: false)
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "Preferences")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+
+                            Picker("Default mode", selection: $defaultModeRawValue) {
+                                ForEach(ActivityMode.allCases) { mode in
+                                    Label(mode.title, systemImage: mode.symbolName)
+                                        .tag(mode.rawValue)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .tint(.goNowAccent)
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 14)
+
+                            Divider().overlay(Color.goNowDivider)
+
+                            Toggle("Help improve GoNow", isOn: $analyticsOptIn)
+                                .tint(.goNowAccent)
+                                .foregroundStyle(Color.goNowSecondaryText)
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 14)
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "GoNow")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            navRow("Pipeline Status", subtitle: "API freshness and ingest health", systemImage: "waveform.path.ecg", route: .status)
+                            Divider().overlay(Color.goNowDivider)
+                            navRow("Formula", subtitle: "Score tiers, gates, and penalties", systemImage: "function", route: .formula)
+                            Divider().overlay(Color.goNowDivider)
+                            navRow("About", subtitle: "Product notes and data sources", systemImage: "info.circle", route: .about)
+                        }
+                    }
+
+                    AppCard(padding: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SectionTitle(title: "Web App")
+                                .padding(.horizontal, 18)
+                                .padding(.vertical, 18)
+                            Divider().overlay(Color.goNowDivider)
+                            profileRow("Status", "Maintained lightly")
+                            Link(destination: URL(string: "https://go-now.dev")!) {
+                                Label("Open public demo", systemImage: "safari")
+                                    .font(.system(size: 16, weight: .semibold))
+                                    .foregroundStyle(Color.goNowAccent)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 18)
+                                    .padding(.vertical, 16)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 28)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+
+    private func navRow(_ title: String, subtitle: String, systemImage: String, route: AppRoute) -> some View {
+        NavigationLink(value: route) {
+            HStack(spacing: 13) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(Color.goNowAccent)
+                    .frame(width: 34, height: 34)
+                    .background(Color.goNowAccent.opacity(0.13), in: Circle())
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.goNowSecondaryText)
+                    Text(subtitle)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(Color.goNowMutedText)
+                        .lineLimit(2)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 14)
+        }
+    }
+
+    private func profileRow(_ title: String, _ value: String, showDivider: Bool = true) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(title)
+                    .foregroundStyle(Color.goNowMutedText)
+                Spacer()
+                Text(value)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Color.goNowSecondaryText)
+            }
+            .font(.subheadline)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 14)
+
+            if showDivider {
+                Divider().overlay(Color.goNowDivider)
+            }
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/Features/Profile/StatusView.swift
+++ b/apps/ios_go_now/GoNow/Features/Profile/StatusView.swift
@@ -1,0 +1,198 @@
+import SwiftUI
+
+struct StatusView: View {
+    let client: any HealthFetching
+    @State private var state: HealthLoadState = .idle
+
+    var body: some View {
+        GoNowScreenBackground(accentLabel: accentLabel) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    Text("Pipeline Status")
+                        .font(.system(size: 32, weight: .bold))
+                        .foregroundStyle(.white)
+
+                    content
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 28)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await loadIfNeeded() }
+        .refreshable { await load() }
+    }
+
+    private var accentLabel: ScoreLabel? {
+        switch state.health?.status {
+        case .healthy: .perfect
+        case .degraded: .meh
+        case .unhealthy: .nope
+        case nil: nil
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .idle, .loading:
+            LoadingRowsView()
+        case .loaded(let health):
+            statusContent(health)
+        case .failed(let message):
+            AppCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    Label("Could not load status", systemImage: "wifi.exclamationmark")
+                        .font(.headline)
+                        .foregroundStyle(Color.reason(.danger))
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(Color.goNowMutedText)
+                    Button("Try Again") {
+                        Task { await load() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.goNowAccent)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func statusContent(_ health: HealthResponse) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            AppCard {
+                VStack(alignment: .leading, spacing: 14) {
+                    Label("System Health", systemImage: "waveform.path.ecg")
+                        .font(.system(size: 13, weight: .semibold))
+                        .textCase(.uppercase)
+                        .tracking(2.2)
+                        .foregroundStyle(Color.goNowMutedText)
+
+                    Text(health.status.rawValue.capitalized)
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .foregroundStyle(color(for: health.status))
+
+                    HStack(spacing: 14) {
+                        statusPill("API \(health.version)", color: Color.score(.good))
+                        statusPill(health.scoringVersion, color: Color.goNowAccent)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            AppCard(padding: 0) {
+                VStack(alignment: .leading, spacing: 0) {
+                    SectionTitle(title: "Forecast Pipeline")
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 18)
+                    Divider().overlay(Color.goNowDivider)
+                    statusRow("Freshness", "\(health.forecast.freshness.rawValue.capitalized) (\(health.forecast.ageMinutes)m ago)", systemImage: "clock")
+                    statusRow("Ingest Status", health.forecast.ingestStatus, systemImage: "tray.and.arrow.down")
+                    statusRow("Hours Available", "\(health.forecast.hoursCount)", systemImage: "calendar")
+                    statusRow("Area", health.forecast.areaId, systemImage: "mappin.and.ellipse")
+                    statusRow("Last Updated", health.forecast.updatedAtUtc?.formatted(date: .abbreviated, time: .shortened) ?? "--", systemImage: "arrow.triangle.2.circlepath", showDivider: false)
+                }
+            }
+
+            AppCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    Label("Live Data Pipeline", systemImage: "point.3.connected.trianglepath.dotted")
+                        .font(.system(size: 13, weight: .semibold))
+                        .textCase(.uppercase)
+                        .tracking(2.2)
+                        .foregroundStyle(Color.goNowMutedText)
+                    pipelineRow("Open-Meteo + AQICN", "Source data")
+                    pipelineRow("Ingest Worker", "Fetch, normalize, load")
+                    pipelineRow("Firestore", "Serving cache")
+                    pipelineRow("FastAPI", "Scores and health")
+                }
+            }
+        }
+    }
+
+    private func statusPill(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption.weight(.bold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(color.opacity(0.13), in: Capsule())
+    }
+
+    private func statusRow(_ title: String, _ value: String, systemImage: String, showDivider: Bool = true) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .foregroundStyle(Color.goNowAccent)
+                    .frame(width: 22)
+                Text(title)
+                    .foregroundStyle(Color.goNowMutedText)
+                Spacer()
+                Text(value)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Color.goNowSecondaryText)
+                    .multilineTextAlignment(.trailing)
+            }
+            .font(.subheadline)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 14)
+
+            if showDivider {
+                Divider().overlay(Color.goNowDivider)
+            }
+        }
+    }
+
+    private func pipelineRow(_ title: String, _ subtitle: String) -> some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(Color.goNowAccent)
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.goNowSecondaryText)
+                Text(subtitle)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(Color.goNowMutedText)
+            }
+            Spacer()
+        }
+    }
+
+    private func color(for status: SystemHealthStatus) -> Color {
+        switch status {
+        case .healthy: .goNowAccent
+        case .degraded: Color.reason(.warning)
+        case .unhealthy: Color.reason(.danger)
+        }
+    }
+
+    private func loadIfNeeded() async {
+        guard case .idle = state else { return }
+        await load()
+    }
+
+    private func load() async {
+        state = .loading
+        do {
+            state = .loaded(try await client.fetchHealth())
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+}
+
+enum HealthLoadState {
+    case idle
+    case loading
+    case loaded(HealthResponse)
+    case failed(String)
+
+    var health: HealthResponse? {
+        if case .loaded(let health) = self { return health }
+        return nil
+    }
+}

--- a/apps/ios_go_now/GoNow/Features/Today/TodayView.swift
+++ b/apps/ios_go_now/GoNow/Features/Today/TodayView.swift
@@ -1,0 +1,392 @@
+import SwiftUI
+
+struct TodayView: View {
+    @EnvironmentObject private var store: ForecastStore
+    @AppStorage("defaultMode") private var defaultModeRawValue = ActivityMode.swimSolo.rawValue
+    @State private var selectedMode: ActivityMode = .swimSolo
+    @State private var selectedHour: ScoredHour?
+    @State private var selectedDay: DayForecast?
+    @State private var selectedMetric: ForecastMetric = .score
+
+    var body: some View {
+        GoNowScreenBackground(accentLabel: accentLabel) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    content
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 28)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
+        .refreshable { await store.refresh() }
+        .task {
+            selectedMode = ActivityMode(rawValue: defaultModeRawValue) ?? .swimSolo
+            await store.loadIfNeeded()
+        }
+        .sheet(item: $selectedHour) { hour in
+            HourDetailSheet(hour: hour, mode: selectedMode)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(item: $selectedDay) { day in
+            if let forecast = store.forecast {
+                DayDetailSheet(day: day, forecast: forecast, mode: selectedMode, initialMetric: selectedMetric)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+    }
+
+    private var accentLabel: ScoreLabel? {
+        guard let forecast = store.forecast,
+              let currentHour = ForecastAnalytics.currentHour(in: forecast) else { return nil }
+        return currentHour.scores[selectedMode].label
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Tel Aviv Coast")
+                .font(.system(size: 32, weight: .bold))
+                .foregroundStyle(.white)
+            Spacer(minLength: 12)
+            if let forecast = store.forecast {
+                FreshnessBadge(ageMinutes: forecast.forecastAgeMinutes)
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch store.state {
+        case .idle, .loading:
+            LoadingRowsView()
+        case .loaded(let forecast), .refreshing(let forecast):
+            forecastContent(forecast)
+        case .failed(let message, let cached):
+            if let cached {
+                warningBanner("Offline. Showing last known forecast. \(message)")
+                forecastContent(cached)
+            } else {
+                EmptyStateView(title: "Could not load forecast", message: message, systemImage: "wifi.exclamationmark")
+            }
+        }
+    }
+
+    private func forecastContent(_ forecast: ScoredForecast) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ModePicker(selection: $selectedMode)
+
+            if ForecastAnalytics.freshnessState(ageMinutes: forecast.forecastAgeMinutes) == .veryStale {
+                warningBanner("Last update was a while ago. Conditions may be off.")
+            }
+
+            if let currentHour = ForecastAnalytics.currentHour(in: forecast) {
+                nowCard(hour: currentHour)
+            }
+
+            upcomingHours(forecast)
+            bestWindowCards(forecast)
+            sevenDayForecast(forecast)
+        }
+    }
+
+    private func nowCard(hour: ScoredHour) -> some View {
+        let score = hour.scores[selectedMode]
+        return VStack(spacing: 18) {
+            HeroScoreView(score: score, mode: selectedMode)
+            ConditionsStrip(hour: hour)
+
+            if !score.reasons.isEmpty {
+                FlowLayout(spacing: 8) {
+                    ForEach(score.reasons.prefix(6)) { chip in
+                        ReasonChipView(chip: chip)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func bestWindowCards(_ forecast: ScoredForecast) -> some View {
+        AppCard(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                SectionTitle(title: "Next Best Window")
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 18)
+                Divider().overlay(Color.goNowDivider)
+                BestWindowCard(window: ForecastAnalytics.bestWindow(in: forecast, mode: selectedMode), mode: selectedMode)
+                    .padding(18)
+            }
+        }
+    }
+
+    private func upcomingHours(_ forecast: ScoredForecast) -> some View {
+        let upcoming = ForecastAnalytics.upcomingHours(in: forecast).prefix(9)
+        return AppCard(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                SectionTitle(title: "Hourly Forecast")
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 18)
+                Divider().overlay(Color.goNowDivider)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 0) {
+                        ForEach(Array(upcoming)) { hour in
+                            HourlyForecastTile(hour: hour, mode: selectedMode)
+                                .frame(width: 92)
+                                .contentShape(Rectangle())
+                                .onTapGesture { selectedHour = hour }
+                        }
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 16)
+                }
+            }
+        }
+    }
+
+    private func sevenDayForecast(_ forecast: ScoredForecast) -> some View {
+        let days = ForecastAnalytics.days(in: forecast)
+        return AppCard(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    SectionTitle(title: "7-Day Forecast")
+                    metricMenu
+                }
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 18)
+                Divider().overlay(Color.goNowDivider)
+
+                ForEach(Array(days.prefix(7))) { day in
+                    Button {
+                        selectedDay = day
+                    } label: {
+                        DayForecastSummaryRow(day: day, mode: selectedMode, metric: selectedMetric)
+                    }
+                    .buttonStyle(.plain)
+                    if day.id != Array(days.prefix(7)).last?.id {
+                        Divider().overlay(Color.goNowDivider)
+                    }
+                }
+            }
+        }
+    }
+
+    private var metricMenu: some View {
+        Menu {
+            ForEach(ForecastMetric.allCases) { metric in
+                Button {
+                    selectedMetric = metric
+                } label: {
+                    Label(metric.label, systemImage: metric.symbolName)
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: selectedMetric.symbolName)
+                    .foregroundStyle(selectedMetric.color)
+                Text(selectedMetric.compactLabel)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.goNowSecondaryText)
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(Color.goNowMutedText)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(Color.white.opacity(0.07), in: Capsule())
+            .overlay {
+                Capsule().stroke(Color.white.opacity(0.09), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func warningBanner(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle.fill")
+            .font(.footnote)
+            .foregroundStyle(Color.reason(.warning))
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.reason(.warning).opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+struct BestWindowCard: View {
+    let window: BestWindow?
+    let mode: ActivityMode
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 27, weight: .semibold))
+                .foregroundStyle(Color.score(window?.label ?? .meh))
+                .frame(width: 44)
+            VStack(alignment: .leading, spacing: 6) {
+                if let window {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("\(window.startHour.hourUtc.goNowDay()) \(window.startHour.hourUtc.goNowHour())-\(window.endHour.hourUtc.goNowHour())")
+                            .font(.system(size: 19, weight: .bold))
+                            .foregroundStyle(Color.goNowSecondaryText)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.78)
+                        Text(window.averageScore.formatted())
+                            .font(.system(size: 20, weight: .bold, design: .rounded))
+                            .foregroundStyle(Color.score(window.label))
+                    }
+                    Text("\(window.lengthHours)h · \(window.label.rawValue)")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.score(window.label))
+                } else {
+                    Text("No good windows today")
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(Color.goNowSecondaryText)
+                    Text(mode.title)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color.goNowMutedText)
+                }
+            }
+            Spacer()
+            Circle()
+                .fill(Color.score(window?.label ?? .meh))
+                .frame(width: 12, height: 12)
+        }
+    }
+}
+
+struct HourSummaryRow: View {
+    let hour: ScoredHour
+    let mode: ActivityMode
+
+    var body: some View {
+        let score = hour.scores[mode]
+        HStack(spacing: 12) {
+            ScoreBadge(score: score, size: 38)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(hour.hourUtc.goNowHour())
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.goNowSecondaryText)
+                Text(score.reasons.first?.text ?? score.label.rawValue)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(Color.goNowMutedText)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Text(score.label.rawValue)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.score(score.label))
+        }
+        .padding(.vertical, 10)
+        .opacity(score.hardGated ? 0.55 : 1)
+    }
+}
+
+struct HourlyForecastTile: View {
+    let hour: ScoredHour
+    let mode: ActivityMode
+
+    var body: some View {
+        let score = hour.scores[mode]
+        VStack(spacing: 11) {
+            Text(hour.hourUtc.goNowHour())
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.goNowMutedText)
+                .monospacedDigit()
+            ScoreBadge(score: score, size: 56)
+            Text(hour.feelslikeC.formattedMetric("°", digits: 0))
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.goNowMutedText)
+        }
+        .padding(.vertical, 2)
+        .opacity(score.hardGated ? 0.55 : 1)
+    }
+}
+
+struct DayForecastSummaryRow: View {
+    let day: DayForecast
+    let mode: ActivityMode
+    let metric: ForecastMetric
+
+    var body: some View {
+        let summary = day.metricSummary(for: metric, mode: mode)
+        let label = summary.bestLabel
+
+        HStack(spacing: 14) {
+            Text(day.title)
+                .font(.system(size: 19, weight: .bold))
+                .foregroundStyle(Color.goNowSecondaryText)
+                .frame(width: 104, alignment: .leading)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+
+            Text(metric.formatted(summary.min))
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(metric == .score ? Color.score(ScoreLabel.label(for: Int(summary.min))) : metric.color)
+                .frame(width: 46, alignment: .trailing)
+                .monospacedDigit()
+
+            MetricRangeBar(metric: metric, minValue: summary.min, maxValue: summary.max)
+
+            Text(metric.formatted(summary.max))
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(metric == .score ? Color.score(ScoreLabel.label(for: Int(summary.max))) : metric.color)
+                .frame(width: 48, alignment: .leading)
+                .monospacedDigit()
+
+            Text(label.rawValue)
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(Color.score(label))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .background(Color.score(label).opacity(0.13), in: Capsule())
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(Color.goNowMutedText)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 17)
+    }
+}
+
+struct MetricRangeBar: View {
+    let metric: ForecastMetric
+    let minValue: Double
+    let maxValue: Double
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let denominator = metric == .score ? 100 : max(maxValue, 1)
+            let start = metric == .score ? width * CGFloat(min(max(minValue / denominator, 0), 1)) : 0
+            let end = metric == .score ? width * CGFloat(min(max(maxValue / denominator, 0), 1)) : width
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.08))
+                    .frame(height: 6)
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: metric == .score
+                                ? [Color.score(ScoreLabel.label(for: Int(minValue))), Color.score(ScoreLabel.label(for: Int(maxValue)))]
+                                : [metric.color.opacity(0.55), metric.color],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: max(end - start, 6), height: 6)
+                    .offset(x: start)
+            }
+        }
+        .frame(height: 6)
+    }
+}

--- a/apps/ios_go_now/GoNow/GoNowApp.swift
+++ b/apps/ios_go_now/GoNow/GoNowApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct GoNowApp: App {
+    @StateObject private var forecastStore = ForecastStore(client: URLSessionForecastClient.live)
+
+    var body: some Scene {
+        WindowGroup {
+            AppRootView()
+                .environmentObject(forecastStore)
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/Networking/ForecastAPIClient.swift
+++ b/apps/ios_go_now/GoNow/Networking/ForecastAPIClient.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+protocol ForecastFetching: Sendable {
+    func fetchScores(days: Int) async throws -> ScoredForecast
+}
+
+protocol HealthFetching: Sendable {
+    func fetchHealth() async throws -> HealthResponse
+}
+
+protocol HTTPSession: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {}
+
+struct URLSessionForecastClient: ForecastFetching, HealthFetching {
+    let baseURL: URL
+    let areaID: String
+    let session: HTTPSession
+    let decoder: JSONDecoder
+
+    static var live: URLSessionForecastClient {
+        URLSessionForecastClient(
+            baseURL: AppConfig.apiBaseURL,
+            areaID: "tel_aviv_coast",
+            session: URLSession.shared,
+            decoder: .goNowAPI
+        )
+    }
+
+    func fetchScores(days: Int = 7) async throws -> ScoredForecast {
+        var components = URLComponents(url: baseURL.appending(path: "/v1/public/scores"), resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "area_id", value: areaID),
+            URLQueryItem(name: "days", value: "\(days)")
+        ]
+
+        guard let url = components?.url else {
+            throw ForecastAPIError.invalidURL
+        }
+
+        return try await requestJSON(url: url)
+    }
+
+    func fetchHealth() async throws -> HealthResponse {
+        let url = baseURL.appending(path: "/v1/public/health")
+        return try await requestJSON(url: url)
+    }
+
+    private func requestJSON<Response: Decodable>(url: URL) async throws -> Response {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 20
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ForecastAPIError.invalidResponse
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            if let envelope = try? decoder.decode(APIErrorEnvelope.self, from: data) {
+                throw ForecastAPIError.server(
+                    statusCode: httpResponse.statusCode,
+                    code: envelope.error.code,
+                    message: envelope.error.message
+                )
+            }
+            throw ForecastAPIError.httpStatus(httpResponse.statusCode)
+        }
+
+        do {
+            return try decoder.decode(Response.self, from: data)
+        } catch {
+            throw ForecastAPIError.decoding(error.localizedDescription)
+        }
+    }
+}
+
+enum AppConfig {
+    static var apiBaseURL: URL {
+        if let override = ProcessInfo.processInfo.environment["GO_NOW_API_BASE_URL"],
+           let url = URL(string: override) {
+            return url
+        }
+        if let index = CommandLine.arguments.firstIndex(of: "--api-base-url"),
+           CommandLine.arguments.indices.contains(index + 1),
+           let url = URL(string: CommandLine.arguments[index + 1]) {
+            return url
+        }
+        return URL(string: "https://api-fastapi-841486153499.europe-west1.run.app")!
+    }
+}
+
+struct APIErrorEnvelope: Decodable {
+    let error: APIErrorDetail
+    let requestId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case requestId = "request_id"
+    }
+}
+
+struct APIErrorDetail: Decodable {
+    let code: String
+    let message: String
+}
+
+enum ForecastAPIError: Error, Equatable, LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case httpStatus(Int)
+    case server(statusCode: Int, code: String, message: String)
+    case decoding(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: "The forecast URL is invalid."
+        case .invalidResponse: "The server returned an unreadable response."
+        case .httpStatus(let status): "Forecast request failed with status \(status)."
+        case .server(_, _, let message): message
+        case .decoding: "The forecast response did not match the app contract."
+        }
+    }
+}

--- a/apps/ios_go_now/GoNow/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/apps/ios_go_now/GoNow/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios_go_now/GoNow/State/ForecastStore.swift
+++ b/apps/ios_go_now/GoNow/State/ForecastStore.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Combine
+
+@MainActor
+final class ForecastStore: ObservableObject {
+    private let client: ForecastFetching
+    @Published private(set) var state: ForecastLoadState = .idle
+    @Published private(set) var lastRefresh: Date?
+
+    init(client: ForecastFetching) {
+        self.client = client
+    }
+
+    var forecast: ScoredForecast? {
+        if case .loaded(let forecast) = state { return forecast }
+        if case .refreshing(let forecast) = state { return forecast }
+        if case .failed(_, let cached) = state { return cached }
+        return nil
+    }
+
+    func loadIfNeeded() async {
+        guard case .idle = state else { return }
+        await refresh()
+    }
+
+    func refresh() async {
+        let cached = forecast
+        state = cached.map(ForecastLoadState.refreshing) ?? .loading
+        do {
+            let forecast = try await client.fetchScores(days: 7)
+            lastRefresh = .now
+            state = .loaded(forecast)
+        } catch is CancellationError {
+            return
+        } catch {
+            state = .failed(message: error.localizedDescription, cached: cached)
+        }
+    }
+}
+
+enum ForecastLoadState {
+    case idle
+    case loading
+    case refreshing(ScoredForecast)
+    case loaded(ScoredForecast)
+    case failed(message: String, cached: ScoredForecast?)
+}
+
+extension ForecastStore {
+    static var previewLoaded: ForecastStore {
+        let store = ForecastStore(client: PreviewForecastClient(result: .success(.preview)))
+        store.state = .loaded(.preview)
+        return store
+    }
+}
+
+struct PreviewForecastClient: ForecastFetching {
+    let result: Result<ScoredForecast, Error>
+
+    func fetchScores(days: Int) async throws -> ScoredForecast {
+        try result.get()
+    }
+}
+
+extension ScoredForecast {
+    static var preview: ScoredForecast {
+        try! JSONDecoder.goNowAPI.decode(ScoredForecast.self, from: previewJSON)
+    }
+
+    private static var previewJSON: Data {
+        """
+        {
+          "area_id": "tel_aviv_coast",
+          "updated_at_utc": "2026-06-18T05:30:00Z",
+          "provider": "open_meteo",
+          "freshness": "fresh",
+          "forecast_age_minutes": 12,
+          "horizon_days": 7,
+          "scoring_version": "score_v2",
+          "daily": [],
+          "hours": [
+            \(previewHour("2026-06-18T05:00:00Z", swim: 88, label: "Perfect")),
+            \(previewHour("2026-06-18T06:00:00Z", swim: 92, label: "Perfect")),
+            \(previewHour("2026-06-18T07:00:00Z", swim: 76, label: "Good")),
+            \(previewHour("2026-06-18T08:00:00Z", swim: 61, label: "Meh")),
+            \(previewHour("2026-06-18T09:00:00Z", swim: 35, label: "Bad")),
+            \(previewHour("2026-06-18T10:00:00Z", swim: 0, label: "Nope"))
+          ]
+        }
+        """.data(using: .utf8)!
+    }
+
+    private static func previewHour(_ hour: String, swim: Int, label: String) -> String {
+        """
+        {
+          "hour_utc": "\(hour)",
+          "wave_height_m": 0.4,
+          "wave_period_s": 5.2,
+          "air_temp_c": 24.0,
+          "feelslike_c": 25.0,
+          "wind_ms": 3.0,
+          "gust_ms": 5.0,
+          "precip_prob_pct": 10,
+          "precip_mm": 0.0,
+          "uv_index": 4.0,
+          "eu_aqi": 42,
+          "pm10": 18.0,
+          "pm2_5": 8.0,
+          "scores": {
+            "swim_solo": \(previewScore(swim, label)),
+            "swim_dog": \(previewScore(max(swim - 3, 0), label)),
+            "run_solo": \(previewScore(84, "Good")),
+            "run_dog": \(previewScore(78, "Good"))
+          }
+        }
+        """
+    }
+
+    private static func previewScore(_ score: Int, _ label: String) -> String {
+        """
+        {
+          "score": \(score),
+          "label": "\(label)",
+          "hard_gated": false,
+          "reasons": [
+            {"factor": "waves", "text": "Waves calm", "emoji": "check", "penalty": 0},
+            {"factor": "uv", "text": "UV manageable", "emoji": "info", "penalty": -3}
+          ]
+        }
+        """
+    }
+}

--- a/apps/ios_go_now/GoNowTests/Fixtures.swift
+++ b/apps/ios_go_now/GoNowTests/Fixtures.swift
@@ -1,0 +1,96 @@
+import Foundation
+@testable import GoNow
+
+enum TestFixtures {
+    static var forecastJSON: Data {
+        """
+        {
+          "area_id": "tel_aviv_coast",
+          "updated_at_utc": "2026-06-18T05:30:00.066482+00:00",
+          "provider": "open_meteo",
+          "freshness": "fresh",
+          "forecast_age_minutes": 12,
+          "horizon_days": 7,
+          "scoring_version": "score_v2",
+          "daily": [
+            {
+              "date": "2026-06-18",
+              "sunrise_utc": "2026-06-18T02:32:00+00:00",
+              "sunset_utc": "2026-06-18T16:52:00+00:00"
+            }
+          ],
+          "hours": [
+            \(hourJSON("2026-06-18T05:00:00Z", swim: 66, label: "Meh")),
+            \(hourJSON("2026-06-18T06:00:00Z", swim: 88, label: "Perfect")),
+            \(hourJSON("2026-06-18T07:00:00Z", swim: 92, label: "Perfect")),
+            \(hourJSON("2026-06-18T08:00:00Z", swim: 76, label: "Good")),
+            \(hourJSON("2026-06-18T09:00:00Z", swim: 42, label: "Bad")),
+            \(hourJSON("2026-06-19T06:00:00Z", swim: 80, label: "Good"))
+          ]
+        }
+        """.data(using: .utf8)!
+    }
+
+    static var forecast: ScoredForecast {
+        try! JSONDecoder.goNowAPI.decode(ScoredForecast.self, from: forecastJSON)
+    }
+
+    static var healthJSON: Data {
+        """
+        {
+          "status": "healthy",
+          "version": "1.0.0",
+          "scoring_version": "score_v2",
+          "forecast": {
+            "area_id": "tel_aviv_coast",
+            "updated_at_utc": "2026-06-18T05:30:00.066482+00:00",
+            "age_minutes": 12,
+            "freshness": "fresh",
+            "ingest_status": "success",
+            "hours_count": 168
+          },
+          "timestamp_utc": "2026-06-18T05:42:00+00:00"
+        }
+        """.data(using: .utf8)!
+    }
+
+    static func hourJSON(_ hour: String, swim: Int, label: String) -> String {
+        """
+        {
+          "hour_utc": "\(hour)",
+          "wave_height_m": 0.4,
+          "wave_period_s": 5.2,
+          "air_temp_c": 24.0,
+          "feelslike_c": 25.0,
+          "wind_ms": 3.0,
+          "gust_ms": 5.0,
+          "precip_prob_pct": 10,
+          "precip_mm": 0.0,
+          "uv_index": 4.0,
+          "eu_aqi": 42,
+          "pm10": 18.0,
+          "pm2_5": 8.0,
+          "scores": {
+            "swim_solo": \(scoreJSON(swim, label)),
+            "swim_dog": \(scoreJSON(max(swim - 3, 0), label)),
+            "run_solo": \(scoreJSON(84, "Good")),
+            "run_dog": \(scoreJSON(78, "Good"))
+          }
+        }
+        """
+    }
+
+    static func scoreJSON(_ score: Int, _ label: String) -> String {
+        """
+        {
+          "score": \(score),
+          "label": "\(label)",
+          "hard_gated": false,
+          "reasons": [
+            {"factor": "waves", "text": "Waves calm", "emoji": "check", "penalty": 0},
+            {"factor": "uv", "text": "UV manageable", "emoji": "info", "penalty": -3}
+          ]
+        }
+        """
+    }
+}

--- a/apps/ios_go_now/GoNowTests/ForecastAPITests.swift
+++ b/apps/ios_go_now/GoNowTests/ForecastAPITests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import XCTest
+@testable import GoNow
+
+final class ForecastAPITests: XCTestCase {
+    func testClientBuildsScoresRequestAndDecodesResponse() async throws {
+        let session = StubSession(data: TestFixtures.forecastJSON, statusCode: 200)
+        let client = URLSessionForecastClient(
+            baseURL: URL(string: "https://example.test")!,
+            areaID: "tel_aviv_coast",
+            session: session,
+            decoder: .goNowAPI
+        )
+
+        let forecast = try await client.fetchScores(days: 7)
+
+        XCTAssertEqual(forecast.hours.count, 6)
+        XCTAssertEqual(session.lastRequest?.url?.path, "/v1/public/scores")
+        XCTAssertEqual(session.lastRequest?.url?.query?.contains("area_id=tel_aviv_coast"), true)
+        XCTAssertEqual(session.lastRequest?.url?.query?.contains("days=7"), true)
+    }
+
+    func testClientMapsAPIErrorEnvelope() async {
+        let body = """
+        {"error":{"code":"NOT_FOUND","message":"No forecast data","details":{}},"request_id":"abc"}
+        """.data(using: .utf8)!
+        let client = URLSessionForecastClient(
+            baseURL: URL(string: "https://example.test")!,
+            areaID: "tel_aviv_coast",
+            session: StubSession(data: body, statusCode: 404),
+            decoder: .goNowAPI
+        )
+
+        do {
+            _ = try await client.fetchScores(days: 7)
+            XCTFail("Expected API error")
+        } catch let error as ForecastAPIError {
+            XCTAssertEqual(error, .server(statusCode: 404, code: "NOT_FOUND", message: "No forecast data"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testClientBuildsHealthRequestAndDecodesResponse() async throws {
+        let session = StubSession(data: TestFixtures.healthJSON, statusCode: 200)
+        let client = URLSessionForecastClient(
+            baseURL: URL(string: "https://example.test")!,
+            areaID: "tel_aviv_coast",
+            session: session,
+            decoder: .goNowAPI
+        )
+
+        let health = try await client.fetchHealth()
+
+        XCTAssertEqual(health.status, .healthy)
+        XCTAssertEqual(session.lastRequest?.url?.path, "/v1/public/health")
+        XCTAssertNil(session.lastRequest?.url?.query)
+    }
+}
+
+final class StubSession: HTTPSession, @unchecked Sendable {
+    let data: Data
+    let statusCode: Int
+    private(set) var lastRequest: URLRequest?
+
+    init(data: Data, statusCode: Int) {
+        self.data = data
+        self.statusCode = statusCode
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lastRequest = request
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (data, response)
+    }
+}

--- a/apps/ios_go_now/GoNowTests/ForecastAnalyticsTests.swift
+++ b/apps/ios_go_now/GoNowTests/ForecastAnalyticsTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import GoNow
+
+final class ForecastAnalyticsTests: XCTestCase {
+    func testCurrentHourUsesLatestHourNotAfterNow() {
+        let now = ISO8601DateFormatter().date(from: "2026-06-18T07:30:00Z")!
+
+        let hour = ForecastAnalytics.currentHour(in: TestFixtures.forecast, now: now)
+
+        XCTAssertEqual(hour?.hourUtc, ISO8601DateFormatter().date(from: "2026-06-18T07:00:00Z"))
+    }
+
+    func testUpcomingHoursSkipsPastHours() {
+        let now = ISO8601DateFormatter().date(from: "2026-06-18T06:30:00Z")!
+
+        let hours = ForecastAnalytics.upcomingHours(in: TestFixtures.forecast, now: now, limit: 2)
+
+        XCTAssertEqual(hours.map(\.hourUtc), [
+            ISO8601DateFormatter().date(from: "2026-06-18T07:00:00Z")!,
+            ISO8601DateFormatter().date(from: "2026-06-18T08:00:00Z")!
+        ])
+    }
+
+    func testBestWindowUsesBestContiguousGoodAverage() {
+        let now = ISO8601DateFormatter().date(from: "2026-06-18T05:30:00Z")!
+
+        let window = ForecastAnalytics.bestWindow(in: TestFixtures.forecast, mode: .swimSolo, now: now)
+
+        XCTAssertEqual(window?.startHour.hourUtc, ISO8601DateFormatter().date(from: "2026-06-18T06:00:00Z"))
+        XCTAssertEqual(window?.endHour.hourUtc, ISO8601DateFormatter().date(from: "2026-06-18T08:00:00Z"))
+        XCTAssertEqual(window?.averageScore, 85)
+        XCTAssertEqual(window?.label, .perfect)
+    }
+
+    func testDaysGroupByJerusalemCalendarDay() {
+        let now = ISO8601DateFormatter().date(from: "2026-06-18T05:00:00Z")!
+
+        let days = ForecastAnalytics.days(in: TestFixtures.forecast, now: now)
+
+        XCTAssertEqual(days.count, 2)
+        XCTAssertEqual(days.first?.title, "Today")
+        XCTAssertEqual(days.first?.hours.count, 5)
+    }
+}

--- a/apps/ios_go_now/GoNowTests/GoNowTests.swift
+++ b/apps/ios_go_now/GoNowTests/GoNowTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import GoNow
+
+final class GoNowTests: XCTestCase {
+    func testDecodesScoredForecastContract() throws {
+        let forecast = try JSONDecoder.goNowAPI.decode(ScoredForecast.self, from: TestFixtures.forecastJSON)
+
+        XCTAssertEqual(forecast.areaId, "tel_aviv_coast")
+        XCTAssertEqual(forecast.scoringVersion, "score_v2")
+        XCTAssertEqual(forecast.hours.count, 6)
+        XCTAssertEqual(forecast.hours[1].scores[.swimSolo].score, 88)
+        XCTAssertEqual(forecast.hours[1].scores[.swimSolo].label, .perfect)
+        XCTAssertEqual(forecast.hours[1].pm25, 8.0)
+    }
+
+    func testModeLabelsMatchProductCopy() {
+        XCTAssertEqual(ActivityMode.swimSolo.title, "Swim")
+        XCTAssertEqual(ActivityMode.swimDog.title, "Swim + Dog")
+        XCTAssertEqual(ActivityMode.runSolo.title, "Run")
+        XCTAssertEqual(ActivityMode.runDog.title, "Run + Dog")
+    }
+
+    func testFreshnessThresholds() {
+        XCTAssertEqual(ForecastAnalytics.freshnessState(ageMinutes: 89), .fresh)
+        XCTAssertEqual(ForecastAnalytics.freshnessState(ageMinutes: 90), .stale)
+        XCTAssertEqual(ForecastAnalytics.freshnessState(ageMinutes: 180), .veryStale)
+    }
+
+    func testDecodesHealthContract() throws {
+        let health = try JSONDecoder.goNowAPI.decode(HealthResponse.self, from: TestFixtures.healthJSON)
+
+        XCTAssertEqual(health.status, .healthy)
+        XCTAssertEqual(health.version, "1.0.0")
+        XCTAssertEqual(health.scoringVersion, "score_v2")
+        XCTAssertEqual(health.forecast.areaId, "tel_aviv_coast")
+        XCTAssertEqual(health.forecast.hoursCount, 168)
+        XCTAssertEqual(health.forecast.freshness, .fresh)
+        XCTAssertNotNil(health.forecast.updatedAtUtc)
+    }
+
+    func testForecastMetricExtractsAndFormatsValues() {
+        let hour = TestFixtures.forecast.hours[1]
+
+        XCTAssertEqual(ForecastMetric.score.value(in: hour, mode: .swimSolo), 88)
+        XCTAssertEqual(ForecastMetric.temperature.formatted(ForecastMetric.temperature.value(in: hour, mode: .swimSolo)), "25°")
+        XCTAssertEqual(ForecastMetric.waves.formatted(ForecastMetric.waves.value(in: hour, mode: .swimSolo)), "0.4m")
+        XCTAssertEqual(ForecastMetric.rain.formatted(ForecastMetric.rain.value(in: hour, mode: .swimSolo)), "10%")
+    }
+
+    func testDayMetricSummaryUsesMetricRangeAndBestScore() {
+        let day = ForecastAnalytics.days(in: TestFixtures.forecast, now: TestFixtures.forecast.hours[0].hourUtc).first!
+        let summary = day.metricSummary(for: .score, mode: .swimSolo)
+
+        XCTAssertEqual(summary.min, 42)
+        XCTAssertEqual(summary.max, 92)
+        XCTAssertEqual(summary.bestScore, 92)
+        XCTAssertEqual(summary.bestLabel, .perfect)
+        XCTAssertEqual(summary.bestHour?.hourUtc, TestFixtures.forecast.hours[2].hourUtc)
+    }
+}

--- a/apps/ios_go_now/README.md
+++ b/apps/ios_go_now/README.md
@@ -1,0 +1,43 @@
+# Go Now iOS
+
+Native SwiftUI client for Go Now. The first release is scoped to native parity with the current public web dashboard and uses the backend scored forecast contract as the source of truth.
+
+## Scope
+
+- iOS 17+ SwiftUI app.
+- Public forecast experience only: Today, Planner, Profile/settings-lite.
+- API scoring via `GET /v1/public/scores?area_id=tel_aviv_coast&days=7`.
+- No Firebase auth, user profiles, push notifications, or on-device scoring in the first release.
+
+## Run
+
+Open `GoNow.xcodeproj` in Xcode and run the `GoNow` scheme on an iPhone simulator.
+
+The app defaults to:
+
+```text
+https://api-fastapi-841486153499.europe-west1.run.app
+```
+
+For local API development, pass a launch argument:
+
+```text
+--api-base-url http://localhost:8080
+```
+
+or set:
+
+```text
+GO_NOW_API_BASE_URL=http://localhost:8080
+```
+
+## Architecture
+
+- `App`: root tab shell and navigation.
+- `Domain`: scored forecast models and forecast analytics.
+- `Networking`: typed URLSession API client and error envelope mapping.
+- `State`: observable forecast loading/cache state.
+- `DesignSystem`: shared score colors, cards, chips, loading/empty states.
+- `Features`: Today, Planner, Profile/settings-lite views.
+
+The web app remains a lightly maintained public demo/status client over the same scored API contract.

--- a/docs/00_README.md
+++ b/docs/00_README.md
@@ -32,6 +32,7 @@ This folder contains the complete planning and specification documents for **Go 
 13. `12_ci_cd_pipeline.md` - GitHub Actions workflows per component, build gates, environment promotion, rollback
 14. `13_observability_data_quality.md` - Metrics catalog, structured logging, SLOs, alert routing, failure runbooks
 15. `14_api_reference.md` - OpenAPI-style endpoint docs with curl examples, error codes, auth details
+16. `15_scored_forecast_contract.md` - Canonical scored forecast contract shared by web and native iOS clients
 
 ## Execution Order (Implementation)
 

--- a/docs/15_scored_forecast_contract.md
+++ b/docs/15_scored_forecast_contract.md
@@ -1,0 +1,72 @@
+# Scored Forecast Contract
+
+This is the canonical public client contract for both the Next.js dashboard and the native iOS app.
+
+## Endpoint
+
+`GET /v1/public/scores?area_id=tel_aviv_coast&days=7`
+
+The backend owns scoring for the first native iOS release. Clients render the returned scored hours and do not reimplement scoring locally.
+
+## Response
+
+```json
+{
+  "area_id": "tel_aviv_coast",
+  "updated_at_utc": "2026-06-18T05:30:00Z",
+  "provider": "open_meteo",
+  "freshness": "fresh",
+  "forecast_age_minutes": 12,
+  "horizon_days": 7,
+  "scoring_version": "score_v2",
+  "hours": [
+    {
+      "hour_utc": "2026-06-18T06:00:00Z",
+      "wave_height_m": 0.4,
+      "wave_period_s": 5.2,
+      "air_temp_c": 24.0,
+      "feelslike_c": 25.0,
+      "wind_ms": 3.0,
+      "gust_ms": 5.0,
+      "precip_prob_pct": 10,
+      "precip_mm": 0.0,
+      "uv_index": 4.0,
+      "eu_aqi": 42,
+      "pm10": 18.0,
+      "pm2_5": 8.0,
+      "scores": {
+        "swim_solo": {
+          "score": 88,
+          "label": "Perfect",
+          "hard_gated": false,
+          "reasons": [
+            {"factor": "waves", "text": "Waves calm", "emoji": "check", "penalty": 0}
+          ]
+        },
+        "swim_dog": {},
+        "run_solo": {},
+        "run_dog": {}
+      }
+    }
+  ],
+  "daily": [
+    {
+      "date": "2026-06-18",
+      "sunrise_utc": "2026-06-18T02:32:00Z",
+      "sunset_utc": "2026-06-18T16:52:00Z"
+    }
+  ]
+}
+```
+
+## Client Rules
+
+- Treat `scores` as authoritative. Do not recompute penalties or hard gates in clients.
+- Render all four modes: `swim_solo`, `swim_dog`, `run_solo`, `run_dog`.
+- Freshness states: `< 90` minutes is fresh, `90...179` is stale, and `>= 180` is very stale.
+- Null raw values render as `--`.
+- API errors use the existing error envelope from `docs/14_api_reference.md`.
+
+## Maintenance Policy
+
+The native iOS app and web dashboard share this contract. The web dashboard remains working and lightly maintained, while new primary product UX work happens in the native iOS app first.


### PR DESCRIPTION
## Summary

- Add a native SwiftUI iPhone app under `apps/ios_go_now` as the new primary product surface.
- Match the web forecast experience with Today, Planner, Profile, day metric charts, day/hour detail flows, Status, Formula, and About screens.
- Document the shared `/v1/public/scores` contract so web and iOS stay aligned on backend-owned scoring.

## Details

- Uses `/v1/public/scores?area_id=tel_aviv_coast&days=7` for forecast and scoring data.
- Adds `/v1/public/health` client/model support for the native Status screen.
- Adds native metric extraction and Charts views for Score, Temperature, UV, Wind, Waves, Rain, and AQI.
- Expands Formula with exact gates, thresholds, penalty tables, dog adjustments, missing-data behavior, and an example calculation.
- Expands Status with a native source-to-client data pipeline and About with the product story, mode rationale, data trust, and maintenance strategy.
- Makes Planner day expansion fully user-controlled with collapsed defaults and accessible expanded/collapsed state.
- Keeps the web app unchanged except documentation updates clarifying shared API usage and iOS ownership.

## Verification

- iOS Simulator build succeeded.
- 13 Swift tests passed with 0 failures.
- App launched successfully on the iPhone 17 simulator.
- Verified Today forecast loading, metric switching, day/hour details, Planner open/close behavior, and Profile navigation.
- Verified Formula, Status, and About at top and bottom scroll positions on a 368-point-wide simulator.

Refs #33. Auth, profiles, notifications, personalized presets, and on-device scoring remain follow-up V2 scope.
